### PR TITLE
parquet: add async parquet file reader

### DIFF
--- a/src/v/serde/parquet/BUILD
+++ b/src/v/serde/parquet/BUILD
@@ -65,6 +65,25 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "assembler",
+    srcs = [
+        "assembler.cc",
+    ],
+    hdrs = [
+        "assembler.h",
+    ],
+    deps = [
+        ":column_array",
+        ":schema",
+        ":value",
+        "//src/v/base",
+        "//src/v/bytes:iobuf",
+        "//src/v/container:chunked_vector",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "column_chunk_reader",
     srcs = [
         "column_chunk_reader.cc",

--- a/src/v/serde/parquet/BUILD
+++ b/src/v/serde/parquet/BUILD
@@ -65,6 +65,45 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "column_chunk_reader",
+    srcs = [
+        "column_chunk_reader.cc",
+    ],
+    hdrs = [
+        "column_chunk_reader.h",
+    ],
+    deps = [
+        ":column_array",
+        ":encoding",
+        ":metadata",
+        ":schema",
+        ":value",
+        "//src/v/base",
+        "//src/v/bytes:iobuf",
+        "//src/v/bytes:iobuf_parser",
+        "//src/v/compression",
+        "//src/v/container:chunked_vector",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
+    name = "column_array",
+    srcs = [
+        "column_array.cc",
+    ],
+    hdrs = [
+        "column_array.h",
+    ],
+    deps = [
+        ":schema",
+        "//src/v/base",
+        "//src/v/bytes:iobuf",
+        "//src/v/container:chunked_vector",
+    ],
+)
+
+redpanda_cc_library(
     name = "encoding",
     srcs = [
         "encoding.cc",

--- a/src/v/serde/parquet/BUILD
+++ b/src/v/serde/parquet/BUILD
@@ -35,6 +35,7 @@ redpanda_cc_library(
         ":schema",
         "//src/v/base",
         "//src/v/bytes:iobuf",
+        "//src/v/bytes:iobuf_parser",
         "//src/v/container:chunked_vector",
         "//src/v/hashing:crc32",
         "//src/v/serde/thrift:compact",

--- a/src/v/serde/parquet/BUILD
+++ b/src/v/serde/parquet/BUILD
@@ -220,7 +220,6 @@ redpanda_cc_library(
     ],
     implementation_deps = [
         ":column_writer",
-        ":metadata",
         ":shredder",
         "//src/v/bytes:iobuf",
         "//src/v/bytes:iostream",
@@ -229,6 +228,7 @@ redpanda_cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        ":metadata",
         ":schema",
         ":value",
         "//src/v/base",

--- a/src/v/serde/parquet/BUILD
+++ b/src/v/serde/parquet/BUILD
@@ -77,8 +77,10 @@ redpanda_cc_library(
         ":value",
         "//src/v/base",
         "//src/v/bytes:iobuf",
+        "//src/v/bytes:iobuf_parser",
         "//src/v/container:chunked_vector",
         "//src/v/utils:vint",
+        "@seastar",
     ],
 )
 

--- a/src/v/serde/parquet/BUILD
+++ b/src/v/serde/parquet/BUILD
@@ -65,6 +65,30 @@ redpanda_cc_library(
 )
 
 redpanda_cc_library(
+    name = "reader",
+    srcs = [
+        "reader.cc",
+    ],
+    hdrs = [
+        "reader.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":assembler",
+        ":column_array",
+        ":column_chunk_reader",
+        ":metadata",
+        ":schema",
+        ":value",
+        "//src/v/base",
+        "//src/v/bytes:iobuf",
+        "//src/v/bytes:iobuf_parser",
+        "//src/v/container:chunked_vector",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_library(
     name = "assembler",
     srcs = [
         "assembler.cc",

--- a/src/v/serde/parquet/assembler.cc
+++ b/src/v/serde/parquet/assembler.cc
@@ -252,6 +252,11 @@ assemble_records(const schema_element& schema, const columnar_batch& batch) {
           });
         ++col_idx;
     });
+    vassert(
+      col_idx == static_cast<int32_t>(batch.columns.size()),
+      "schema has {} leaf columns but batch has {} columns",
+      col_idx,
+      batch.columns.size());
 
     chunked_vector<group_value> records;
     for (int64_t row = 0; row < batch.num_rows; ++row) {

--- a/src/v/serde/parquet/assembler.cc
+++ b/src/v/serde/parquet/assembler.cc
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "serde/parquet/assembler.h"
+
+#include <seastar/util/variant_utils.hh>
+
+#include <stdexcept>
+
+namespace serde::parquet {
+
+namespace {
+
+/// Per-column cursor state during assembly.
+struct column_cursor {
+    const column_array* data;
+    const chunked_vector<def_level>* def_levels;
+    const chunked_vector<rep_level>* rep_levels;
+    size_t level_index = 0;
+    size_t value_index = 0;
+
+    def_level current_def() const { return (*def_levels)[level_index]; }
+    rep_level current_rep() const { return (*rep_levels)[level_index]; }
+    bool exhausted() const { return level_index >= def_levels->size(); }
+    void advance_level() { ++level_index; }
+    void advance_value() { ++value_index; }
+};
+
+/// Read the next non-null value from a column cursor.
+value read_leaf_value(column_cursor& cursor) {
+    auto idx = cursor.value_index;
+    cursor.advance_value();
+    return ss::visit(
+      cursor.data->data,
+      [&](const column_array::boolean_data& d) -> value {
+          auto byte_idx = idx / CHAR_BIT;
+          auto bit_idx = idx % CHAR_BIT;
+          for (const auto& frag : d.packed_bits) {
+              auto frag_size = static_cast<size_t>(frag.size());
+              if (byte_idx < frag_size) {
+                  auto byte = static_cast<uint8_t>(frag.get()[byte_idx]);
+                  return boolean_value{
+                    static_cast<bool>((byte >> bit_idx) & 1)};
+              }
+              byte_idx -= frag_size;
+          }
+          throw std::runtime_error("boolean value index out of range");
+      },
+      [&](const column_array::i32_data& d) -> value {
+          return int32_value{d.values[idx]};
+      },
+      [&](const column_array::i64_data& d) -> value {
+          return int64_value{d.values[idx]};
+      },
+      [&](const column_array::f32_data& d) -> value {
+          return float32_value{d.values[idx]};
+      },
+      [&](const column_array::f64_data& d) -> value {
+          return float64_value{d.values[idx]};
+      },
+      [&](const column_array::byte_array_data& d) -> value {
+          auto start = d.offsets[idx];
+          auto end = d.offsets[idx + 1];
+          auto len = static_cast<size_t>(end - start);
+          // Copy the slice from the concatenated data iobuf.
+          iobuf result;
+          size_t remaining = len;
+          size_t skip = static_cast<size_t>(start);
+          for (const auto& frag : d.data) {
+              if (skip >= frag.size()) {
+                  skip -= frag.size();
+                  continue;
+              }
+              auto copy_len = std::min(frag.size() - skip, remaining);
+              result.append(frag.get() + skip, copy_len);
+              remaining -= copy_len;
+              skip = 0;
+              if (remaining == 0) {
+                  break;
+              }
+          }
+          return byte_array_value{std::move(result)};
+      },
+      [&](const column_array::fixed_byte_array_data& d) -> value {
+          auto offset = static_cast<size_t>(idx) * d.fixed_length;
+          iobuf result;
+          size_t remaining = d.fixed_length;
+          size_t skip = offset;
+          for (const auto& frag : d.data) {
+              if (skip >= frag.size()) {
+                  skip -= frag.size();
+                  continue;
+              }
+              auto copy_len = std::min(frag.size() - skip, remaining);
+              result.append(frag.get() + skip, copy_len);
+              remaining -= copy_len;
+              skip = 0;
+              if (remaining == 0) {
+                  break;
+              }
+          }
+          return fixed_byte_array_value{std::move(result)};
+      });
+}
+
+/// Map from schema element position to column cursor index.
+struct cursor_map {
+    /// cursor_index[schema_position] = index into cursors vector, or -1.
+    chunked_vector<int32_t> cursor_index;
+    chunked_vector<column_cursor> cursors;
+
+    column_cursor& get(int32_t schema_position) {
+        return cursors[cursor_index[schema_position]];
+    }
+};
+
+/// Find the first leaf descendant of a schema node, used to peek at
+/// the current def/rep levels for non-leaf nodes.
+const schema_element& first_leaf(const schema_element& node) {
+    if (node.is_leaf()) {
+        return node;
+    }
+    return first_leaf(node.children[0]);
+}
+
+value assemble_value(const schema_element& node, cursor_map& cursors);
+
+value assemble_leaf(const schema_element& leaf, cursor_map& cursors) {
+    auto& cursor = cursors.get(leaf.position);
+    auto dl = cursor.current_def();
+    cursor.advance_level();
+
+    if (dl < leaf.max_definition_level) {
+        return null_value();
+    }
+    return read_leaf_value(cursor);
+}
+
+value assemble_group(const schema_element& node, cursor_map& cursors) {
+    group_value fields;
+    for (const auto& child : node.children) {
+        fields.push_back(group_member{assemble_value(child, cursors)});
+    }
+    return value(std::move(fields));
+}
+
+value assemble_repeated(const schema_element& node, cursor_map& cursors) {
+    const auto& leaf = first_leaf(node);
+    auto& leaf_cursor = cursors.get(leaf.position);
+
+    // Check if the entire repeated field is null (empty list).
+    auto dl = leaf_cursor.current_def();
+    if (dl < node.max_definition_level) {
+        // Null at or above this node's level — consume levels for all
+        // descendant leaves and return null.
+        for (auto& child : node.children) {
+            child.for_each([&](const schema_element& elem) {
+                if (elem.is_leaf()) {
+                    cursors.get(elem.position).advance_level();
+                }
+            });
+        }
+        return null_value();
+    }
+
+    repeated_value elements;
+    // First element: assemble using the node's optional semantics.
+    // For repeated group nodes, the shredder processes them as optional
+    // group values within the repeated wrapper.
+    if (node.is_leaf()) {
+        elements.push_back(repeated_element{assemble_leaf(node, cursors)});
+    } else {
+        elements.push_back(repeated_element{assemble_group(node, cursors)});
+    }
+
+    // Subsequent elements: continue while rep_level >= this node's max_rep.
+    while (!leaf_cursor.exhausted()
+           && leaf_cursor.current_rep() >= node.max_repetition_level) {
+        if (node.is_leaf()) {
+            elements.push_back(repeated_element{assemble_leaf(node, cursors)});
+        } else {
+            elements.push_back(repeated_element{assemble_group(node, cursors)});
+        }
+    }
+    return value(std::move(elements));
+}
+
+value assemble_value(const schema_element& node, cursor_map& cursors) {
+    if (node.repetition_type == field_repetition_type::repeated) {
+        return assemble_repeated(node, cursors);
+    }
+
+    if (node.is_leaf()) {
+        return assemble_leaf(node, cursors);
+    }
+
+    // For optional group nodes, check if the value is null by peeking
+    // at the first descendant leaf's def level.
+    if (node.repetition_type == field_repetition_type::optional) {
+        const auto& leaf = first_leaf(node);
+        auto& leaf_cursor = cursors.get(leaf.position);
+        auto dl = leaf_cursor.current_def();
+        if (dl < node.max_definition_level) {
+            // Null at this group level — consume levels for all leaves.
+            for (const auto& child : node.children) {
+                child.for_each([&](const schema_element& elem) {
+                    if (elem.is_leaf()) {
+                        cursors.get(elem.position).advance_level();
+                    }
+                });
+            }
+            return null_value();
+        }
+    }
+
+    return assemble_group(node, cursors);
+}
+
+} // namespace
+
+chunked_vector<group_value>
+assemble_records(const schema_element& schema, const columnar_batch& batch) {
+    // Build cursor map from schema positions to column indices.
+    cursor_map cmap;
+    int32_t max_position = 0;
+    schema.for_each([&](const schema_element& elem) {
+        max_position = std::max(max_position, elem.position);
+    });
+    for (int32_t i = 0; i <= max_position; ++i) {
+        cmap.cursor_index.push_back(-1);
+    }
+
+    int32_t col_idx = 0;
+    schema.for_each([&](const schema_element& elem) {
+        if (!elem.is_leaf()) {
+            return;
+        }
+        cmap.cursor_index[elem.position] = col_idx;
+        cmap.cursors.push_back(
+          column_cursor{
+            .data = &batch.columns[col_idx],
+            .def_levels = &batch.levels[col_idx].def_levels,
+            .rep_levels = &batch.levels[col_idx].rep_levels,
+          });
+        ++col_idx;
+    });
+
+    chunked_vector<group_value> records;
+    for (int64_t row = 0; row < batch.num_rows; ++row) {
+        // Each row assembles a group_value from the root's children.
+        group_value fields;
+        for (const auto& child : schema.children) {
+            fields.push_back(group_member{assemble_value(child, cmap)});
+        }
+        records.push_back(std::move(fields));
+    }
+    return records;
+}
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/assembler.h
+++ b/src/v/serde/parquet/assembler.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "serde/parquet/column_array.h"
+#include "serde/parquet/schema.h"
+#include "serde/parquet/value.h"
+
+namespace serde::parquet {
+
+/// \brief Assemble records from columnar data with definition/repetition
+/// levels.
+///
+/// This is the inverse of shred_record(). The fundamental correctness
+/// property: for any schema S and value V, assemble(shred(V)) == V.
+chunked_vector<group_value>
+assemble_records(const schema_element& schema, const columnar_batch& batch);
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/column_array.cc
+++ b/src/v/serde/parquet/column_array.cc
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "serde/parquet/column_array.h"
+
+namespace serde::parquet {
+
+// column_array and columnar_batch are pure data structures with no
+// non-trivial methods. This file exists for the build target.
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/column_array.h
+++ b/src/v/serde/parquet/column_array.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "container/chunked_vector.h"
+#include "serde/parquet/schema.h"
+
+#include <cstdint>
+#include <variant>
+
+namespace serde::parquet {
+
+// TODO: Nullability is currently tracked via definition levels in
+// columnar_batch::level_data, not via a per-column validity bitmap. If a
+// future execution/scan layer needs a materialized bitmap for vectorized null
+// skipping (as Arrow and Velox do), derive it from def levels at that
+// boundary. A chunked_vector<uint64_t>-backed packed bitmap with O(1) access
+// would be the natural choice — see the assembler for how def levels map to
+// null positions.
+
+/// \brief A decoded column of homogeneous physical type.
+///
+/// Fixed-width types use chunked_vector<T> (128KiB chunks, O(1) access).
+/// Variable-width types use offset+iobuf.
+/// Null positions are not tracked here — use the corresponding def levels
+/// in columnar_batch::level_data.
+struct column_array {
+    physical_type ptype;
+    logical_type ltype;
+
+    struct boolean_data {
+        iobuf packed_bits;
+        int64_t num_values = 0;
+    };
+    struct i32_data {
+        chunked_vector<int32_t> values;
+    };
+    struct i64_data {
+        chunked_vector<int64_t> values;
+    };
+    struct f32_data {
+        chunked_vector<float> values;
+    };
+    struct f64_data {
+        chunked_vector<double> values;
+    };
+    struct byte_array_data {
+        /// N+1 offsets for N non-null values. offsets[0] == 0.
+        chunked_vector<int64_t> offsets;
+        /// Concatenated byte arrays.
+        iobuf data;
+    };
+    struct fixed_byte_array_data {
+        int32_t fixed_length = 0;
+        /// Concatenated fixed-length values.
+        iobuf data;
+    };
+
+    using data_type = std::variant<
+      boolean_data,
+      i32_data,
+      i64_data,
+      f32_data,
+      f64_data,
+      byte_array_data,
+      fixed_byte_array_data>;
+
+    data_type data;
+
+    /// Total number of logical values (including nulls).
+    int64_t length = 0;
+};
+
+/// \brief A batch of decoded columns from one row group.
+///
+/// Nested types are NOT materialized as nested column_array structures —
+/// they stay as flat leaf columns with definition/repetition levels,
+/// assembled lazily by the record assembler.
+struct columnar_batch {
+    /// One column_array per leaf in the schema, ordered by schema position.
+    chunked_vector<column_array> columns;
+
+    struct level_data {
+        chunked_vector<def_level> def_levels;
+        chunked_vector<rep_level> rep_levels;
+    };
+
+    /// Definition and repetition levels for each column.
+    chunked_vector<level_data> levels;
+
+    int64_t num_rows = 0;
+};
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/column_chunk_reader.cc
+++ b/src/v/serde/parquet/column_chunk_reader.cc
@@ -1,0 +1,454 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "serde/parquet/column_chunk_reader.h"
+
+#include "compression/compression.h"
+#include "compression/snappy_standard_compressor.h"
+#include "serde/parquet/encoding.h"
+
+#include <seastar/coroutine/maybe_yield.hh>
+#include <seastar/util/variant_utils.hh>
+
+namespace serde::parquet {
+
+namespace {
+
+ss::future<iobuf> decompress_data(
+  iobuf data, compression_codec codec, int32_t uncompressed_size) {
+    switch (codec) {
+    case compression_codec::uncompressed:
+        co_return std::move(data);
+    case compression_codec::zstd:
+        co_return co_await compression::stream_compressor::uncompress(
+          std::move(data), compression::type::zstd);
+    case compression_codec::snappy:
+        co_return compression::snappy_standard_compressor::uncompress(data);
+    default:
+        throw std::runtime_error(
+          fmt::format(
+            "unsupported compression codec: {}", static_cast<int>(codec)));
+    }
+}
+
+void append_to_column_array(
+  column_array& arr, iobuf_parser_base& data_parser, int32_t num_non_null) {
+    ss::visit(
+      arr.data,
+      [&](column_array::boolean_data& d) {
+          plain_decoder<boolean_value> dec(data_parser);
+          uint8_t current_byte = 0;
+          auto start_bit = d.num_values % CHAR_BIT;
+          if (start_bit != 0) {
+              // Continue partial byte — not expected across pages in V2,
+              // but handle defensively.
+              current_byte = 0;
+          }
+          for (int32_t i = 0; i < num_non_null; ++i) {
+              auto bit_pos = (d.num_values + i) % CHAR_BIT;
+              current_byte |= static_cast<uint8_t>(dec.read_value().val)
+                              << bit_pos;
+              if (bit_pos == CHAR_BIT - 1) {
+                  d.packed_bits.append(&current_byte, 1);
+                  current_byte = 0;
+              }
+          }
+          if ((d.num_values + num_non_null) % CHAR_BIT != 0) {
+              d.packed_bits.append(&current_byte, 1);
+          }
+          d.num_values += num_non_null;
+      },
+      [&](column_array::i32_data& d) {
+          plain_decoder<int32_value> dec(data_parser);
+          for (int32_t i = 0; i < num_non_null; ++i) {
+              d.values.push_back(dec.read_value().val);
+          }
+      },
+      [&](column_array::i64_data& d) {
+          plain_decoder<int64_value> dec(data_parser);
+          for (int32_t i = 0; i < num_non_null; ++i) {
+              d.values.push_back(dec.read_value().val);
+          }
+      },
+      [&](column_array::f32_data& d) {
+          plain_decoder<float32_value> dec(data_parser);
+          for (int32_t i = 0; i < num_non_null; ++i) {
+              d.values.push_back(dec.read_value().val);
+          }
+      },
+      [&](column_array::f64_data& d) {
+          plain_decoder<float64_value> dec(data_parser);
+          for (int32_t i = 0; i < num_non_null; ++i) {
+              d.values.push_back(dec.read_value().val);
+          }
+      },
+      [&](column_array::byte_array_data& d) {
+          plain_decoder<byte_array_value> dec(data_parser);
+          for (int32_t i = 0; i < num_non_null; ++i) {
+              auto v = dec.read_value();
+              auto len = static_cast<int64_t>(v.val.size_bytes());
+              d.data.append(std::move(v.val));
+              d.offsets.push_back(d.offsets.back() + len);
+          }
+      },
+      [&](column_array::fixed_byte_array_data& d) {
+          plain_decoder<fixed_byte_array_value> dec(
+            data_parser, d.fixed_length);
+          for (int32_t i = 0; i < num_non_null; ++i) {
+              d.data.append(std::move(dec.read_value().val));
+          }
+      });
+}
+
+chunked_vector<value> decode_dictionary_plain(
+  iobuf_parser_base& parser,
+  int32_t num_values,
+  const schema_element& schema_elem) {
+    chunked_vector<value> dict;
+    dict.reserve(num_values);
+    ss::visit(
+      schema_elem.type,
+      [&](const std::monostate&) {
+          plain_decoder<boolean_value> dec(parser);
+          for (int32_t i = 0; i < num_values; ++i) {
+              dict.push_back(dec.read_value());
+          }
+      },
+      [&](const bool_type&) {
+          plain_decoder<boolean_value> dec(parser);
+          for (int32_t i = 0; i < num_values; ++i) {
+              dict.push_back(dec.read_value());
+          }
+      },
+      [&](const i32_type&) {
+          plain_decoder<int32_value> dec(parser);
+          for (int32_t i = 0; i < num_values; ++i) {
+              dict.push_back(dec.read_value());
+          }
+      },
+      [&](const i64_type&) {
+          plain_decoder<int64_value> dec(parser);
+          for (int32_t i = 0; i < num_values; ++i) {
+              dict.push_back(dec.read_value());
+          }
+      },
+      [&](const f32_type&) {
+          plain_decoder<float32_value> dec(parser);
+          for (int32_t i = 0; i < num_values; ++i) {
+              dict.push_back(dec.read_value());
+          }
+      },
+      [&](const f64_type&) {
+          plain_decoder<float64_value> dec(parser);
+          for (int32_t i = 0; i < num_values; ++i) {
+              dict.push_back(dec.read_value());
+          }
+      },
+      [&](const byte_array_type& t) {
+          if (t.fixed_length.has_value()) {
+              plain_decoder<fixed_byte_array_value> dec(
+                parser, *t.fixed_length);
+              for (int32_t i = 0; i < num_values; ++i) {
+                  dict.push_back(dec.read_value());
+              }
+          } else {
+              plain_decoder<byte_array_value> dec(parser);
+              for (int32_t i = 0; i < num_values; ++i) {
+                  dict.push_back(dec.read_value());
+              }
+          }
+      });
+    return dict;
+}
+
+void append_dictionary_values(
+  column_array& arr,
+  const chunked_vector<value>& dictionary,
+  const chunked_vector<int32_t>& indices) {
+    ss::visit(
+      arr.data,
+      [&](column_array::boolean_data& d) {
+          uint8_t current_byte = 0;
+          for (auto idx : indices) {
+              const auto& v = std::get<boolean_value>(dictionary[idx]);
+              auto bit_pos = d.num_values % CHAR_BIT;
+              current_byte |= static_cast<uint8_t>(v.val) << bit_pos;
+              if (bit_pos == CHAR_BIT - 1) {
+                  d.packed_bits.append(&current_byte, 1);
+                  current_byte = 0;
+              }
+              ++d.num_values;
+          }
+          if (d.num_values % CHAR_BIT != 0) {
+              d.packed_bits.append(&current_byte, 1);
+          }
+      },
+      [&](column_array::i32_data& d) {
+          for (auto idx : indices) {
+              d.values.push_back(std::get<int32_value>(dictionary[idx]).val);
+          }
+      },
+      [&](column_array::i64_data& d) {
+          for (auto idx : indices) {
+              d.values.push_back(std::get<int64_value>(dictionary[idx]).val);
+          }
+      },
+      [&](column_array::f32_data& d) {
+          for (auto idx : indices) {
+              d.values.push_back(std::get<float32_value>(dictionary[idx]).val);
+          }
+      },
+      [&](column_array::f64_data& d) {
+          for (auto idx : indices) {
+              d.values.push_back(std::get<float64_value>(dictionary[idx]).val);
+          }
+      },
+      [&](column_array::byte_array_data& d) {
+          for (auto idx : indices) {
+              const auto& v = std::get<byte_array_value>(dictionary[idx]);
+              auto len = static_cast<int64_t>(v.val.size_bytes());
+              d.data.append(v.val.copy());
+              d.offsets.push_back(d.offsets.back() + len);
+          }
+      },
+      [&](column_array::fixed_byte_array_data& d) {
+          for (auto idx : indices) {
+              const auto& v = std::get<fixed_byte_array_value>(dictionary[idx]);
+              d.data.append(v.val.copy());
+          }
+      });
+}
+
+/// Decode values from a data section, dispatching on PLAIN vs dictionary.
+void decode_data_values(
+  column_array& arr,
+  iobuf encoded_data,
+  encoding data_encoding,
+  int32_t num_non_null,
+  const chunked_vector<value>& dictionary) {
+    iobuf_parser data_parser(std::move(encoded_data));
+    if (
+      data_encoding == encoding::rle_dictionary
+      || data_encoding == encoding::plain_dictionary) {
+        auto bit_width = static_cast<int32_t>(
+          data_parser.consume_type<uint8_t>());
+        auto remaining = static_cast<int32_t>(data_parser.bytes_left());
+        auto indices = decode_rle_bp_int32(
+          data_parser, num_non_null, remaining, bit_width);
+        append_dictionary_values(arr, dictionary, indices);
+    } else {
+        append_to_column_array(arr, data_parser, num_non_null);
+    }
+}
+
+column_array make_empty_column_array(const schema_element& schema_elem) {
+    column_array arr;
+    arr.ptype = schema_elem.type;
+    arr.ltype = schema_elem.logical_type;
+    ss::visit(
+      schema_elem.type,
+      [&](const std::monostate&) {
+          arr.data.emplace<column_array::boolean_data>();
+      },
+      [&](const bool_type&) { arr.data.emplace<column_array::boolean_data>(); },
+      [&](const i32_type&) { arr.data.emplace<column_array::i32_data>(); },
+      [&](const i64_type&) { arr.data.emplace<column_array::i64_data>(); },
+      [&](const f32_type&) { arr.data.emplace<column_array::f32_data>(); },
+      [&](const f64_type&) { arr.data.emplace<column_array::f64_data>(); },
+      [&](const byte_array_type& t) {
+          if (t.fixed_length.has_value()) {
+              arr.data.emplace<column_array::fixed_byte_array_data>(
+                column_array::fixed_byte_array_data{
+                  .fixed_length = *t.fixed_length});
+          } else {
+              auto& d = arr.data.emplace<column_array::byte_array_data>();
+              d.offsets.push_back(0);
+          }
+      });
+    return arr;
+}
+
+} // namespace
+
+ss::future<column_chunk_data> decode_column_chunk(
+  iobuf data, const column_meta_data& meta, const schema_element& schema_elem) {
+    iobuf_parser parser(std::move(data));
+
+    auto arr = make_empty_column_array(schema_elem);
+    chunked_vector<def_level> all_def_levels;
+    chunked_vector<rep_level> all_rep_levels;
+    chunked_vector<value> dictionary;
+
+    while (parser.bytes_left() > 0) {
+        auto header = decode(parser, page_header_tag{});
+
+        if (auto* dph = std::get_if<dictionary_page_header>(&header.type)) {
+            iobuf page_bytes = parser.copy(header.compressed_page_size);
+            if (meta.codec != compression_codec::uncompressed) {
+                page_bytes = co_await decompress_data(
+                  std::move(page_bytes),
+                  meta.codec,
+                  header.uncompressed_page_size);
+            }
+            iobuf_parser dict_parser(std::move(page_bytes));
+            dictionary = decode_dictionary_plain(
+              dict_parser, dph->num_values, schema_elem);
+            continue;
+        }
+
+        if (auto* v2 = std::get_if<data_page_header>(&header.type)) {
+            auto num_non_null = v2->num_values - v2->num_nulls;
+
+            iobuf rep_level_bytes;
+            if (v2->repetition_levels_byte_length > 0) {
+                rep_level_bytes = parser.copy(
+                  v2->repetition_levels_byte_length);
+            }
+            iobuf def_level_bytes;
+            if (v2->definition_levels_byte_length > 0) {
+                def_level_bytes = parser.copy(
+                  v2->definition_levels_byte_length);
+            }
+
+            auto data_size = header.compressed_page_size
+                             - v2->repetition_levels_byte_length
+                             - v2->definition_levels_byte_length;
+            iobuf encoded_data = parser.copy(data_size);
+
+            if (v2->is_compressed) {
+                auto uncompressed_data_size
+                  = header.uncompressed_page_size
+                    - v2->repetition_levels_byte_length
+                    - v2->definition_levels_byte_length;
+                encoded_data = co_await decompress_data(
+                  std::move(encoded_data), meta.codec, uncompressed_data_size);
+            }
+
+            if (v2->repetition_levels_byte_length > 0) {
+                iobuf_parser rep_parser(std::move(rep_level_bytes));
+                auto levels = decode_levels(
+                  rep_parser,
+                  v2->num_values,
+                  v2->repetition_levels_byte_length,
+                  schema_elem.max_repetition_level);
+                for (auto& l : levels) {
+                    all_rep_levels.push_back(l);
+                }
+            } else {
+                for (int32_t i = 0; i < v2->num_values; ++i) {
+                    all_rep_levels.push_back(rep_level(0));
+                }
+            }
+
+            if (v2->definition_levels_byte_length > 0) {
+                iobuf_parser def_parser(std::move(def_level_bytes));
+                auto levels = decode_levels(
+                  def_parser,
+                  v2->num_values,
+                  v2->definition_levels_byte_length,
+                  schema_elem.max_definition_level);
+                for (auto& l : levels) {
+                    all_def_levels.push_back(l);
+                }
+            } else {
+                for (int32_t i = 0; i < v2->num_values; ++i) {
+                    all_def_levels.push_back(schema_elem.max_definition_level);
+                }
+            }
+
+            decode_data_values(
+              arr,
+              std::move(encoded_data),
+              v2->data_encoding,
+              num_non_null,
+              dictionary);
+            arr.length += v2->num_values;
+            co_await ss::coroutine::maybe_yield();
+            continue;
+        }
+
+        if (auto* v1 = std::get_if<data_page_header_v1>(&header.type)) {
+            iobuf page_bytes = parser.copy(header.compressed_page_size);
+            if (meta.codec != compression_codec::uncompressed) {
+                page_bytes = co_await decompress_data(
+                  std::move(page_bytes),
+                  meta.codec,
+                  header.uncompressed_page_size);
+            }
+            iobuf_parser body(std::move(page_bytes));
+
+            // V1: levels are prefixed with a 4-byte LE length.
+            if (schema_elem.max_repetition_level > rep_level(0)) {
+                auto rep_len = ss::le_to_cpu(body.consume_type<int32_t>());
+                iobuf rep_bytes = body.copy(rep_len);
+                iobuf_parser rep_parser(std::move(rep_bytes));
+                auto levels = decode_levels(
+                  rep_parser,
+                  v1->num_values,
+                  rep_len,
+                  schema_elem.max_repetition_level);
+                for (auto& l : levels) {
+                    all_rep_levels.push_back(l);
+                }
+            } else {
+                for (int32_t i = 0; i < v1->num_values; ++i) {
+                    all_rep_levels.push_back(rep_level(0));
+                }
+            }
+
+            int32_t num_nulls = 0;
+            if (schema_elem.max_definition_level > def_level(0)) {
+                auto def_len = ss::le_to_cpu(body.consume_type<int32_t>());
+                iobuf def_bytes = body.copy(def_len);
+                iobuf_parser def_parser(std::move(def_bytes));
+                auto levels = decode_levels(
+                  def_parser,
+                  v1->num_values,
+                  def_len,
+                  schema_elem.max_definition_level);
+                for (auto& l : levels) {
+                    if (l < schema_elem.max_definition_level) {
+                        ++num_nulls;
+                    }
+                    all_def_levels.push_back(l);
+                }
+            } else {
+                for (int32_t i = 0; i < v1->num_values; ++i) {
+                    all_def_levels.push_back(schema_elem.max_definition_level);
+                }
+            }
+
+            auto num_non_null = v1->num_values - num_nulls;
+            iobuf remaining_data = body.copy(body.bytes_left());
+
+            decode_data_values(
+              arr,
+              std::move(remaining_data),
+              v1->data_encoding,
+              num_non_null,
+              dictionary);
+            arr.length += v1->num_values;
+            co_await ss::coroutine::maybe_yield();
+            continue;
+        }
+
+        // Skip unknown page types (e.g. index pages).
+        parser.skip(header.compressed_page_size);
+    }
+
+    co_return column_chunk_data{
+      .values = std::move(arr),
+      .def_levels = std::move(all_def_levels),
+      .rep_levels = std::move(all_rep_levels),
+    };
+}
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/column_chunk_reader.h
+++ b/src/v/serde/parquet/column_chunk_reader.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "serde/parquet/column_array.h"
+#include "serde/parquet/metadata.h"
+
+#include <seastar/core/future.hh>
+
+namespace serde::parquet {
+
+/// Decoded column data from a single column chunk.
+struct column_chunk_data {
+    column_array values;
+    chunked_vector<def_level> def_levels;
+    chunked_vector<rep_level> rep_levels;
+};
+
+/// \brief Decode all pages in a column chunk from serialized bytes.
+///
+/// Handles Data Page V1, V2, and dictionary pages. Decompresses if needed
+/// (async for ZSTD). Supports PLAIN and RLE_DICTIONARY data encodings.
+/// The input `data` should contain exactly the bytes for this column chunk
+/// (total_compressed_size bytes starting at dictionary_page_offset or
+/// data_page_offset).
+ss::future<column_chunk_data> decode_column_chunk(
+  iobuf data, const column_meta_data& meta, const schema_element& schema_elem);
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/column_writer.cc
+++ b/src/v/serde/parquet/column_writer.cc
@@ -12,6 +12,7 @@
 #include "serde/parquet/column_writer.h"
 
 #include "absl/numeric/int128.h"
+#include "bytes/iobuf_parser.h"
 #include "compression/compression.h"
 #include "container/chunked_vector.h"
 #include "hashing/crc32.h"
@@ -48,6 +49,34 @@ public:
 };
 
 namespace {
+
+std::pair<iobuf, bool> truncate_min(iobuf value, int32_t max_len) {
+    if (max_len <= 0 || static_cast<int32_t>(value.size_bytes()) <= max_len) {
+        return {std::move(value), true};
+    }
+    iobuf_parser parser(std::move(value));
+    return {parser.copy(max_len), false};
+}
+
+std::pair<iobuf, bool> truncate_max(iobuf value, int32_t max_len) {
+    if (max_len <= 0 || static_cast<int32_t>(value.size_bytes()) <= max_len) {
+        return {std::move(value), true};
+    }
+    iobuf_parser parser(std::move(value));
+    auto prefix = parser.read_bytes(max_len);
+    for (int i = static_cast<int>(prefix.size()) - 1; i >= 0; --i) {
+        if (prefix[i] < 0xFF) {
+            prefix[i]++;
+            iobuf result;
+            result.append(prefix.data(), i + 1);
+            return {std::move(result), false};
+        }
+    }
+    // All bytes are 0xFF -- can't form a tight upper bound, keep full prefix
+    iobuf result;
+    result.append(prefix.data(), prefix.size());
+    return {std::move(result), true};
+}
 
 void extend_crc32(crc::crc32& crc, const iobuf& buf) {
     for (const auto& frag : buf) {
@@ -137,20 +166,16 @@ public:
         using bound_type = decltype(_flushed_stats)::bound_ref_type;
         std::optional<statistics::bound> max_bound;
         if (bound_type max = _current_page_stats.max()) {
-            // TODO: consider truncating large values instead of writing them
-            // (is_exact=false)
-            max_bound.emplace(
-              /*value=*/encode_for_stats(*max),
-              /*is_exact=*/true);
+            auto [val, is_exact] = truncate_max(
+              encode_for_stats(*max), _opts.max_stats_truncate_length);
+            max_bound.emplace(std::move(val), is_exact);
             _flushed_stats.record_value(*max);
         }
         std::optional<statistics::bound> min_bound;
         if (bound_type min = _current_page_stats.min()) {
-            // TODO: consider truncating large values instead of writing them
-            // (is_exact=false)
-            min_bound.emplace(
-              /*value=*/encode_for_stats(*min),
-              /*is_exact=*/true);
+            auto [val, is_exact] = truncate_min(
+              encode_for_stats(*min), _opts.max_stats_truncate_length);
+            min_bound.emplace(std::move(val), is_exact);
             _flushed_stats.record_value(*min);
         }
         _flushed_stats.record_null(_current_page_stats.null_count());
@@ -218,14 +243,14 @@ public:
         };
         using bound_type = decltype(_flushed_stats)::bound_ref_type;
         if (bound_type max = _flushed_stats.max()) {
-            full_stats.max.emplace(
-              /*value=*/encode_for_stats(*max),
-              /*is_exact=*/true);
+            auto [val, is_exact] = truncate_max(
+              encode_for_stats(*max), _opts.max_stats_truncate_length);
+            full_stats.max.emplace(std::move(val), is_exact);
         }
         if (bound_type min = _flushed_stats.min()) {
-            full_stats.min.emplace(
-              /*value=*/encode_for_stats(*min),
-              /*is_exact=*/true);
+            auto [val, is_exact] = truncate_min(
+              encode_for_stats(*min), _opts.max_stats_truncate_length);
+            full_stats.min.emplace(std::move(val), is_exact);
         }
         _flushed_stats.reset();
         _total_memory_usage = 0;

--- a/src/v/serde/parquet/column_writer.h
+++ b/src/v/serde/parquet/column_writer.h
@@ -48,6 +48,8 @@ public:
     struct options {
         // If true, use zstd compression for the column data.
         bool compress;
+        // Max byte length for byte array column statistics truncation.
+        int32_t max_stats_truncate_length = 16;
     };
 
     explicit column_writer(const schema_element&, options);

--- a/src/v/serde/parquet/encoding.cc
+++ b/src/v/serde/parquet/encoding.cc
@@ -184,4 +184,258 @@ iobuf encode_for_stats(float64_value v) {
 }
 iobuf encode_for_stats(const byte_array_value& v) { return v.val.copy(); }
 iobuf encode_for_stats(const fixed_byte_array_value& v) { return v.val.copy(); }
+
+boolean_value decode_stats_boolean(const iobuf& data) {
+    iobuf_const_parser parser(data);
+    plain_decoder<boolean_value> dec(parser);
+    return dec.read_value();
+}
+int32_value decode_stats_int32(const iobuf& data) {
+    iobuf_const_parser parser(data);
+    plain_decoder<int32_value> dec(parser);
+    return dec.read_value();
+}
+int64_value decode_stats_int64(const iobuf& data) {
+    iobuf_const_parser parser(data);
+    plain_decoder<int64_value> dec(parser);
+    return dec.read_value();
+}
+float32_value decode_stats_float32(const iobuf& data) {
+    iobuf_const_parser parser(data);
+    plain_decoder<float32_value> dec(parser);
+    return dec.read_value();
+}
+float64_value decode_stats_float64(const iobuf& data) {
+    iobuf_const_parser parser(data);
+    plain_decoder<float64_value> dec(parser);
+    return dec.read_value();
+}
+byte_array_value decode_stats_byte_array(const iobuf& data) {
+    return byte_array_value{data.copy()};
+}
+
+namespace {
+
+template<typename level_type>
+level_type read_level_value(iobuf_parser_base& parser, size_t bit_width) {
+    if (bit_width > CHAR_WIDTH) {
+        auto v = parser.consume_type<int16_t>();
+        return level_type(ss::le_to_cpu(v));
+    }
+    return level_type(parser.consume_type<uint8_t>());
+}
+
+template<typename level_type>
+chunked_vector<level_type> decode_levels_impl(
+  iobuf_parser_base& parser,
+  int32_t num_values,
+  int32_t byte_length,
+  level_type max_value) {
+    size_t bit_width = std::bit_width(static_cast<uint16_t>(max_value()));
+    chunked_vector<level_type> result;
+    result.reserve(num_values);
+    size_t start_pos = parser.bytes_consumed();
+    size_t end_pos = start_pos + byte_length;
+
+    if (bit_width == 0) {
+        // All values are 0. The encoder writes count << 1 and the value.
+        auto [header, _] = parser.read_unsigned_varint();
+        auto count = header >> 1U;
+        auto val = read_level_value<level_type>(parser, bit_width);
+        for (uint32_t i = 0;
+             i < count && result.size() < static_cast<size_t>(num_values);
+             ++i) {
+            result.push_back(val);
+        }
+        // Skip any remaining bytes
+        if (parser.bytes_consumed() < end_pos) {
+            parser.skip(end_pos - parser.bytes_consumed());
+        }
+        return result;
+    }
+
+    while (parser.bytes_consumed() < end_pos
+           && result.size() < static_cast<size_t>(num_values)) {
+        auto [header, _] = parser.read_unsigned_varint();
+        if ((header & 1U) == 0) {
+            // RLE run: count = header >> 1, followed by value
+            auto count = header >> 1U;
+            auto val = read_level_value<level_type>(parser, bit_width);
+            for (uint32_t i = 0;
+                 i < count && result.size() < static_cast<size_t>(num_values);
+                 ++i) {
+                result.push_back(val);
+            }
+        } else {
+            // Bitpack run: num_groups = header >> 1
+            // Each group has 8 values packed in bit_width bits
+            auto num_groups = header >> 1U;
+            auto total_values = num_groups * 8;
+            size_t bits_remaining = 0;
+            uint64_t buffer = 0;
+            uint64_t mask = (1ULL << bit_width) - 1;
+            for (uint32_t i = 0; i < total_values; ++i) {
+                while (bits_remaining < bit_width) {
+                    buffer
+                      |= static_cast<uint64_t>(parser.consume_type<uint8_t>())
+                         << bits_remaining;
+                    bits_remaining += 8;
+                }
+                auto val = static_cast<int16_t>(buffer & mask);
+                buffer >>= bit_width;
+                bits_remaining -= bit_width;
+                if (result.size() < static_cast<size_t>(num_values)) {
+                    result.push_back(level_type(val));
+                }
+            }
+        }
+    }
+    // Ensure we consumed exactly byte_length bytes
+    if (parser.bytes_consumed() < end_pos) {
+        parser.skip(end_pos - parser.bytes_consumed());
+    }
+    return result;
+}
+
+} // namespace
+
+chunked_vector<rep_level> decode_levels(
+  iobuf_parser_base& parser,
+  int32_t num_values,
+  int32_t byte_length,
+  rep_level max_value) {
+    return decode_levels_impl(parser, num_values, byte_length, max_value);
+}
+
+chunked_vector<def_level> decode_levels(
+  iobuf_parser_base& parser,
+  int32_t num_values,
+  int32_t byte_length,
+  def_level max_value) {
+    return decode_levels_impl(parser, num_values, byte_length, max_value);
+}
+
+chunked_vector<int32_t> decode_rle_bp_int32(
+  iobuf_parser_base& parser,
+  int32_t num_values,
+  int32_t byte_length,
+  int32_t bit_width) {
+    chunked_vector<int32_t> result;
+    result.reserve(num_values);
+    size_t start_pos = parser.bytes_consumed();
+    size_t end_pos = start_pos + byte_length;
+    size_t bw = static_cast<size_t>(bit_width);
+
+    if (bw == 0) {
+        auto [header, _] = parser.read_unsigned_varint();
+        auto count = header >> 1U;
+        // Value bytes: ceil(bit_width/8) = 0, but encoder writes 1 byte.
+        auto val = static_cast<int32_t>(parser.consume_type<uint8_t>());
+        for (uint32_t i = 0;
+             i < count && result.size() < static_cast<size_t>(num_values);
+             ++i) {
+            result.push_back(val);
+        }
+        if (parser.bytes_consumed() < end_pos) {
+            parser.skip(end_pos - parser.bytes_consumed());
+        }
+        return result;
+    }
+
+    size_t value_bytes = (bw + 7) / 8;
+
+    while (parser.bytes_consumed() < end_pos
+           && result.size() < static_cast<size_t>(num_values)) {
+        auto [header, _] = parser.read_unsigned_varint();
+        if ((header & 1U) == 0) {
+            // RLE run
+            auto count = header >> 1U;
+            int32_t val = 0;
+            for (size_t b = 0; b < value_bytes; ++b) {
+                val |= static_cast<int32_t>(parser.consume_type<uint8_t>())
+                       << (b * 8);
+            }
+            for (uint32_t i = 0;
+                 i < count && result.size() < static_cast<size_t>(num_values);
+                 ++i) {
+                result.push_back(val);
+            }
+        } else {
+            // Bitpack run
+            auto num_groups = header >> 1U;
+            auto total_values = num_groups * 8;
+            size_t bits_remaining = 0;
+            uint64_t buffer = 0;
+            uint64_t mask = (1ULL << bw) - 1;
+            for (uint32_t i = 0; i < total_values; ++i) {
+                while (bits_remaining < bw) {
+                    buffer
+                      |= static_cast<uint64_t>(parser.consume_type<uint8_t>())
+                         << bits_remaining;
+                    bits_remaining += 8;
+                }
+                auto val = static_cast<int32_t>(buffer & mask);
+                buffer >>= bw;
+                bits_remaining -= bw;
+                if (result.size() < static_cast<size_t>(num_values)) {
+                    result.push_back(val);
+                }
+            }
+        }
+    }
+    if (parser.bytes_consumed() < end_pos) {
+        parser.skip(end_pos - parser.bytes_consumed());
+    }
+    return result;
+}
+
+plain_decoder<boolean_value>::plain_decoder(iobuf_parser_base& parser)
+  : _parser(parser) {}
+
+boolean_value plain_decoder<boolean_value>::read_value() {
+    if (_shift >= CHAR_BIT) {
+        _bits = _parser.consume_type<uint8_t>();
+        _shift = 0;
+    }
+    bool val = (_bits >> _shift) & 1;
+    ++_shift;
+    return boolean_value{val};
+}
+
+template<typename value_type>
+numeric_plain_decoder<value_type>::numeric_plain_decoder(
+  iobuf_parser_base& parser)
+  : _parser(parser) {}
+
+template<typename value_type>
+value_type numeric_plain_decoder<value_type>::read_value() {
+    auto raw = _parser.consume_type<decltype(value_type::val)>();
+    if constexpr (std::is_integral_v<decltype(value_type::val)>) {
+        raw = ss::le_to_cpu(raw);
+    }
+    return value_type{raw};
+}
+
+template class numeric_plain_decoder<int32_value>;
+template class numeric_plain_decoder<int64_value>;
+template class numeric_plain_decoder<float32_value>;
+template class numeric_plain_decoder<float64_value>;
+
+plain_decoder<byte_array_value>::plain_decoder(iobuf_parser_base& parser)
+  : _parser(parser) {}
+
+byte_array_value plain_decoder<byte_array_value>::read_value() {
+    auto len = ss::le_to_cpu(_parser.consume_type<int32_t>());
+    return byte_array_value{_parser.copy(len)};
+}
+
+plain_decoder<fixed_byte_array_value>::plain_decoder(
+  iobuf_parser_base& parser, int32_t fixed_length)
+  : _parser(parser)
+  , _fixed_length(fixed_length) {}
+
+fixed_byte_array_value plain_decoder<fixed_byte_array_value>::read_value() {
+    return fixed_byte_array_value{_parser.copy(_fixed_length)};
+}
+
 } // namespace serde::parquet

--- a/src/v/serde/parquet/encoding.h
+++ b/src/v/serde/parquet/encoding.h
@@ -11,8 +11,11 @@
 
 #pragma once
 
+#include "bytes/iobuf_parser.h"
 #include "serde/parquet/schema.h"
 #include "serde/parquet/value.h"
+
+#include <climits>
 
 namespace serde::parquet {
 
@@ -107,5 +110,112 @@ iobuf encode_for_stats(float32_value);
 iobuf encode_for_stats(float64_value);
 iobuf encode_for_stats(const byte_array_value&);
 iobuf encode_for_stats(const fixed_byte_array_value&);
+
+// Decode stats-encoded values (inverse of encode_for_stats).
+// For byte arrays, the entire iobuf is the value (no length prefix).
+boolean_value decode_stats_boolean(const iobuf& data);
+int32_value decode_stats_int32(const iobuf& data);
+int64_value decode_stats_int64(const iobuf& data);
+float32_value decode_stats_float32(const iobuf& data);
+float64_value decode_stats_float64(const iobuf& data);
+byte_array_value decode_stats_byte_array(const iobuf& data);
+
+// Decode RLE/bitpack hybrid encoded levels. Handles both RLE runs (from
+// our own encoder) and bitpack runs (from external writers like Arrow).
+//
+// `byte_length` is the number of encoded bytes (from page header V2).
+// `max_value` provides the bit width for decoding.
+chunked_vector<rep_level> decode_levels(
+  iobuf_parser_base& parser,
+  int32_t num_values,
+  int32_t byte_length,
+  rep_level max_value);
+
+chunked_vector<def_level> decode_levels(
+  iobuf_parser_base& parser,
+  int32_t num_values,
+  int32_t byte_length,
+  def_level max_value);
+
+// Decode RLE/bitpack hybrid encoded int32 values. Same wire format as
+// definition/repetition levels. Used for dictionary indices.
+//
+// `bit_width` is the number of bits per value (provided by the caller,
+// not derived from a max_value).
+// `byte_length` is the total encoded byte count.
+chunked_vector<int32_t> decode_rle_bp_int32(
+  iobuf_parser_base& parser,
+  int32_t num_values,
+  int32_t byte_length,
+  int32_t bit_width);
+
+// Decode PLAIN encoded values.
+template<typename value_type>
+class plain_decoder;
+
+template<>
+class plain_decoder<boolean_value> {
+public:
+    explicit plain_decoder(iobuf_parser_base& parser);
+    boolean_value read_value();
+
+private:
+    iobuf_parser_base& _parser;
+    uint8_t _bits{0};
+    uint8_t _shift{CHAR_BIT}; // start exhausted so first read fetches a byte
+};
+
+template<typename value_type>
+class numeric_plain_decoder {
+public:
+    explicit numeric_plain_decoder(iobuf_parser_base& parser);
+    value_type read_value();
+
+private:
+    iobuf_parser_base& _parser;
+};
+
+template<>
+class plain_decoder<int32_value> : public numeric_plain_decoder<int32_value> {
+    using numeric_plain_decoder::numeric_plain_decoder;
+};
+
+template<>
+class plain_decoder<int64_value> : public numeric_plain_decoder<int64_value> {
+    using numeric_plain_decoder::numeric_plain_decoder;
+};
+
+template<>
+class plain_decoder<float32_value>
+  : public numeric_plain_decoder<float32_value> {
+    using numeric_plain_decoder::numeric_plain_decoder;
+};
+
+template<>
+class plain_decoder<float64_value>
+  : public numeric_plain_decoder<float64_value> {
+    using numeric_plain_decoder::numeric_plain_decoder;
+};
+
+template<>
+class plain_decoder<byte_array_value> {
+public:
+    explicit plain_decoder(iobuf_parser_base& parser);
+    byte_array_value read_value();
+
+private:
+    iobuf_parser_base& _parser;
+};
+
+template<>
+class plain_decoder<fixed_byte_array_value> {
+public:
+    plain_decoder(iobuf_parser_base& parser, int32_t fixed_length);
+    fixed_byte_array_value read_value();
+
+private:
+    iobuf_parser_base& _parser;
+    int32_t _fixed_length;
+};
 
 } // namespace serde::parquet

--- a/src/v/serde/parquet/flattened_schema.cc
+++ b/src/v/serde/parquet/flattened_schema.cc
@@ -27,4 +27,33 @@ chunked_vector<flattened_schema> flatten(const schema_element& root) {
     return flattened;
 }
 
+namespace {
+
+schema_element
+unflatten_recursive(const chunked_vector<flattened_schema>& flat, size_t& idx) {
+    const auto& elem = flat[idx];
+    schema_element result;
+    result.type = elem.type;
+    result.repetition_type = elem.repetition_type;
+    result.path.push_back(elem.name);
+    result.field_id = elem.field_id;
+    result.logical_type = elem.logical_type;
+    ++idx;
+    for (int32_t i = 0; i < elem.num_children; ++i) {
+        result.children.push_back(unflatten_recursive(flat, idx));
+    }
+    return result;
+}
+
+} // namespace
+
+schema_element unflatten(const chunked_vector<flattened_schema>& flat) {
+    if (flat.empty()) {
+        return {};
+    }
+    size_t idx = 0;
+    auto result = unflatten_recursive(flat, idx);
+    return result;
+}
+
 } // namespace serde::parquet

--- a/src/v/serde/parquet/flattened_schema.cc
+++ b/src/v/serde/parquet/flattened_schema.cc
@@ -11,6 +11,8 @@
 
 #include "serde/parquet/flattened_schema.h"
 
+#include <stdexcept>
+
 namespace serde::parquet {
 
 chunked_vector<flattened_schema> flatten(const schema_element& root) {
@@ -31,6 +33,10 @@ namespace {
 
 schema_element
 unflatten_recursive(const chunked_vector<flattened_schema>& flat, size_t& idx) {
+    if (idx >= flat.size()) {
+        throw std::runtime_error(
+          "malformed flattened schema: num_children exceeds element count");
+    }
     const auto& elem = flat[idx];
     schema_element result;
     result.type = elem.type;
@@ -53,6 +59,10 @@ schema_element unflatten(const chunked_vector<flattened_schema>& flat) {
     }
     size_t idx = 0;
     auto result = unflatten_recursive(flat, idx);
+    if (idx != flat.size()) {
+        throw std::runtime_error(
+          "malformed flattened schema: not all elements consumed");
+    }
     return result;
 }
 

--- a/src/v/serde/parquet/flattened_schema.h
+++ b/src/v/serde/parquet/flattened_schema.h
@@ -63,4 +63,14 @@ struct flattened_schema {
  */
 chunked_vector<flattened_schema> flatten(const schema_element& root);
 
+/**
+ * Reconstruct a schema_element tree from a flattened (depth-first pre-order)
+ * schema list. This is the inverse of flatten().
+ *
+ * The resulting tree has only name, type, repetition_type, field_id, and
+ * logical_type populated. Call index_schema() to compute position, paths,
+ * and max definition/repetition levels.
+ */
+schema_element unflatten(const chunked_vector<flattened_schema>& flat);
+
 } // namespace serde::parquet

--- a/src/v/serde/parquet/metadata.cc
+++ b/src/v/serde/parquet/metadata.cc
@@ -859,6 +859,36 @@ iobuf encode(const dictionary_page_header& header) {
     return std::move(encoder).write_stop();
 }
 
+iobuf encode(const data_page_header_v1& header) {
+    constexpr auto num_values_field_id = thrift::field_id(1);
+    constexpr auto encoding_field_id = thrift::field_id(2);
+    constexpr auto definition_level_encoding_field_id = thrift::field_id(3);
+    constexpr auto repetition_level_encoding_field_id = thrift::field_id(4);
+    constexpr auto stats_field_id = thrift::field_id(5);
+    thrift::struct_encoder encoder;
+    encoder.write_field(
+      num_values_field_id,
+      thrift::field_type::i32,
+      vint::to_bytes(header.num_values));
+    encoder.write_field(
+      encoding_field_id,
+      thrift::field_type::i32,
+      vint::to_bytes(static_cast<int32_t>(header.data_encoding)));
+    encoder.write_field(
+      definition_level_encoding_field_id,
+      thrift::field_type::i32,
+      vint::to_bytes(static_cast<int32_t>(header.definition_level_encoding)));
+    encoder.write_field(
+      repetition_level_encoding_field_id,
+      thrift::field_type::i32,
+      vint::to_bytes(static_cast<int32_t>(header.repetition_level_encoding)));
+    if (header.stats) {
+        encoder.write_field(
+          stats_field_id, thrift::field_type::structure, encode(*header.stats));
+    }
+    return std::move(encoder).write_stop();
+}
+
 } // namespace
 
 iobuf encode(const page_header& header) {
@@ -866,7 +896,7 @@ iobuf encode(const page_header& header) {
     constexpr auto uncompressed_page_size_field_id = thrift::field_id(2);
     constexpr auto compressed_page_size_field_id = thrift::field_id(3);
     constexpr auto crc_field_id = thrift::field_id(4);
-    // constexpr auto data_page_header_field_id = thrift::field_id(5);
+    constexpr auto data_page_header_v1_field_id = thrift::field_id(5);
     constexpr auto index_page_header_field_id = thrift::field_id(6);
     constexpr auto dictionary_page_header_field_id = thrift::field_id(7);
     constexpr auto data_page_header_v2_field_id = thrift::field_id(8);
@@ -881,7 +911,8 @@ iobuf encode(const page_header& header) {
       header.type,
       [](const index_page_header&) { return page_type::index_page; },
       [](const data_page_header&) { return page_type::data_page_v2; },
-      [](const dictionary_page_header&) { return page_type::dictionary_page; });
+      [](const dictionary_page_header&) { return page_type::dictionary_page; },
+      [](const data_page_header_v1&) { return page_type::data_page; });
     encoder.write_field(
       type_field_id,
       thrift::field_type::i32,
@@ -918,8 +949,698 @@ iobuf encode(const page_header& header) {
             dictionary_page_header_field_id,
             thrift::field_type::structure,
             encode(h));
+      },
+      [&](const data_page_header_v1& h) {
+          encoder.write_field(
+            data_page_header_v1_field_id,
+            thrift::field_type::structure,
+            encode(h));
       });
     return std::move(encoder).write_stop();
+}
+
+namespace {
+
+physical_type decode_physical_type(int32_t type_val) {
+    enum physical_type_enum : int8_t {
+        boolean = 0,
+        int32 = 1,
+        int64 = 2,
+        float32 = 4,
+        float64 = 5,
+        byte_array = 6,
+        fixed_len_byte_array = 7,
+    };
+    switch (type_val) {
+    case physical_type_enum::boolean:
+        return bool_type();
+    case physical_type_enum::int32:
+        return i32_type();
+    case physical_type_enum::int64:
+        return i64_type();
+    case physical_type_enum::float32:
+        return f32_type();
+    case physical_type_enum::float64:
+        return f64_type();
+    case physical_type_enum::byte_array:
+        return byte_array_type();
+    case physical_type_enum::fixed_len_byte_array:
+        return byte_array_type();
+    default:
+        return std::monostate();
+    }
+}
+
+time_unit decode_time_unit(iobuf_parser_base& parser) {
+    thrift::struct_decoder dec(parser);
+    time_unit result = time_unit::millis;
+    while (auto hdr = dec.read_field_header()) {
+        switch (hdr->id()) {
+        case 1:
+            result = time_unit::millis;
+            // skip empty struct
+            {
+                thrift::struct_decoder inner(parser);
+                while (auto ihdr = inner.read_field_header()) {
+                    inner.skip_field(ihdr->type);
+                }
+            }
+            break;
+        case 2:
+            result = time_unit::micros;
+            {
+                thrift::struct_decoder inner(parser);
+                while (auto ihdr = inner.read_field_header()) {
+                    inner.skip_field(ihdr->type);
+                }
+            }
+            break;
+        case 3:
+            result = time_unit::nanos;
+            {
+                thrift::struct_decoder inner(parser);
+                while (auto ihdr = inner.read_field_header()) {
+                    inner.skip_field(ihdr->type);
+                }
+            }
+            break;
+        default:
+            dec.skip_field(hdr->type);
+            break;
+        }
+    }
+    return result;
+}
+
+logical_type
+decode_logical_type(iobuf_parser_base& parser, int32_t& out_scale) {
+    enum logical_type_id : int16_t {
+        string = 1,
+        map = 2,
+        list = 3,
+        enumeration = 4,
+        decimal = 5,
+        date = 6,
+        time = 7,
+        timestamp = 8,
+        integer = 10,
+        null = 11,
+        json = 12,
+        bson = 13,
+        uuid = 14,
+        float16 = 15,
+    };
+
+    logical_type result;
+    thrift::struct_decoder dec(parser);
+    while (auto hdr = dec.read_field_header()) {
+        switch (hdr->id()) {
+        case logical_type_id::string:
+            result = string_type();
+            dec.skip_field(hdr->type);
+            break;
+        case logical_type_id::map:
+            result = map_type();
+            dec.skip_field(hdr->type);
+            break;
+        case logical_type_id::list:
+            result = list_type();
+            dec.skip_field(hdr->type);
+            break;
+        case logical_type_id::enumeration:
+            result = enum_type();
+            dec.skip_field(hdr->type);
+            break;
+        case logical_type_id::decimal: {
+            thrift::struct_decoder inner(parser);
+            decimal_type dt;
+            while (auto ihdr = inner.read_field_header()) {
+                switch (ihdr->id()) {
+                case 1:
+                    dt.scale = thrift::decode_i32(parser);
+                    break;
+                case 2:
+                    dt.precision = thrift::decode_i32(parser);
+                    break;
+                default:
+                    inner.skip_field(ihdr->type);
+                    break;
+                }
+            }
+            out_scale = dt.scale;
+            result = dt;
+            break;
+        }
+        case logical_type_id::date:
+            result = date_type();
+            dec.skip_field(hdr->type);
+            break;
+        case logical_type_id::time: {
+            thrift::struct_decoder inner(parser);
+            time_type tt;
+            while (auto ihdr = inner.read_field_header()) {
+                switch (ihdr->id()) {
+                case 1:
+                    tt.is_adjusted_to_utc = ihdr->type
+                                            == thrift::field_type::boolean_true;
+                    break;
+                case 2:
+                    tt.unit = decode_time_unit(parser);
+                    break;
+                default:
+                    inner.skip_field(ihdr->type);
+                    break;
+                }
+            }
+            result = tt;
+            break;
+        }
+        case logical_type_id::timestamp: {
+            thrift::struct_decoder inner(parser);
+            timestamp_type ts;
+            while (auto ihdr = inner.read_field_header()) {
+                switch (ihdr->id()) {
+                case 1:
+                    ts.is_adjusted_to_utc = ihdr->type
+                                            == thrift::field_type::boolean_true;
+                    break;
+                case 2:
+                    ts.unit = decode_time_unit(parser);
+                    break;
+                default:
+                    inner.skip_field(ihdr->type);
+                    break;
+                }
+            }
+            result = ts;
+            break;
+        }
+        case logical_type_id::integer: {
+            thrift::struct_decoder inner(parser);
+            int_type it;
+            while (auto ihdr = inner.read_field_header()) {
+                switch (ihdr->id()) {
+                case 1:
+                    it.bit_width = parser.consume_type<int8_t>();
+                    break;
+                case 2:
+                    it.is_signed = ihdr->type
+                                   == thrift::field_type::boolean_true;
+                    break;
+                default:
+                    inner.skip_field(ihdr->type);
+                    break;
+                }
+            }
+            result = it;
+            break;
+        }
+        case logical_type_id::null:
+            result = null_type();
+            dec.skip_field(hdr->type);
+            break;
+        case logical_type_id::json:
+            result = json_type();
+            dec.skip_field(hdr->type);
+            break;
+        case logical_type_id::bson:
+            result = bson_type();
+            dec.skip_field(hdr->type);
+            break;
+        case logical_type_id::uuid:
+            result = uuid_type();
+            dec.skip_field(hdr->type);
+            break;
+        case logical_type_id::float16:
+            result = f16_type();
+            dec.skip_field(hdr->type);
+            break;
+        default:
+            dec.skip_field(hdr->type);
+            break;
+        }
+    }
+    return result;
+}
+
+flattened_schema
+decode_flattened_schema(iobuf_parser_base& parser, bool /*is_root*/) {
+    constexpr auto type_field_id = thrift::field_id(1);
+    constexpr auto type_length_field_id = thrift::field_id(2);
+    constexpr auto repetition_type_field_id = thrift::field_id(3);
+    constexpr auto name_field_id = thrift::field_id(4);
+    constexpr auto num_children_field_id = thrift::field_id(5);
+    constexpr auto scale_field_id = thrift::field_id(7);
+    constexpr auto precision_field_id = thrift::field_id(8);
+    constexpr auto field_id_field_id = thrift::field_id(9);
+    constexpr auto logical_type_field_id = thrift::field_id(10);
+
+    flattened_schema result;
+    result.repetition_type = field_repetition_type::required;
+    std::optional<int32_t> type_length;
+
+    thrift::struct_decoder dec(parser);
+    while (auto hdr = dec.read_field_header()) {
+        if (hdr->id == type_field_id) {
+            auto ptype = thrift::decode_i32(parser);
+            result.type = decode_physical_type(ptype);
+        } else if (hdr->id == type_length_field_id) {
+            type_length = thrift::decode_i32(parser);
+        } else if (hdr->id == repetition_type_field_id) {
+            result.repetition_type = static_cast<field_repetition_type>(
+              thrift::decode_i32(parser));
+        } else if (hdr->id == name_field_id) {
+            result.name = thrift::decode_string(parser);
+        } else if (hdr->id == num_children_field_id) {
+            result.num_children = thrift::decode_i32(parser);
+        } else if (hdr->id == scale_field_id) {
+            // Legacy scale field (for decimal) — handled by logical type
+            thrift::decode_i32(parser);
+        } else if (hdr->id == precision_field_id) {
+            // Legacy precision field — handled by logical type
+            thrift::decode_i32(parser);
+        } else if (hdr->id == field_id_field_id) {
+            result.field_id = thrift::decode_i32(parser);
+        } else if (hdr->id == logical_type_field_id) {
+            int32_t scale = 0;
+            result.logical_type = decode_logical_type(parser, scale);
+        } else {
+            dec.skip_field(hdr->type);
+        }
+    }
+
+    if (type_length.has_value()) {
+        if (auto* ba = std::get_if<byte_array_type>(&result.type)) {
+            ba->fixed_length = type_length;
+        }
+    }
+
+    return result;
+}
+
+statistics decode_statistics(iobuf_parser_base& parser) {
+    constexpr auto null_count_field_id = thrift::field_id(3);
+    constexpr auto max_value_field_id = thrift::field_id(5);
+    constexpr auto min_value_field_id = thrift::field_id(6);
+    constexpr auto is_max_value_exact_field_id = thrift::field_id(7);
+    constexpr auto is_min_value_exact_field_id = thrift::field_id(8);
+
+    statistics result;
+    result.null_count = std::nullopt;
+    thrift::struct_decoder dec(parser);
+    while (auto hdr = dec.read_field_header()) {
+        if (hdr->id == null_count_field_id) {
+            result.null_count = thrift::decode_i64(parser);
+        } else if (hdr->id == max_value_field_id) {
+            result.max = statistics::bound{
+              .value = thrift::decode_binary(parser)};
+        } else if (hdr->id == min_value_field_id) {
+            result.min = statistics::bound{
+              .value = thrift::decode_binary(parser)};
+        } else if (hdr->id == is_max_value_exact_field_id) {
+            if (result.max) {
+                result.max->is_exact = hdr->type
+                                       == thrift::field_type::boolean_true;
+            }
+        } else if (hdr->id == is_min_value_exact_field_id) {
+            if (result.min) {
+                result.min->is_exact = hdr->type
+                                       == thrift::field_type::boolean_true;
+            }
+        } else {
+            dec.skip_field(hdr->type);
+        }
+    }
+    return result;
+}
+
+column_meta_data decode_column_meta_data(iobuf_parser_base& parser) {
+    constexpr auto type_field_id = thrift::field_id(1);
+    constexpr auto encodings_field_id = thrift::field_id(2);
+    constexpr auto path_in_schema_field_id = thrift::field_id(3);
+    constexpr auto codec_field_id = thrift::field_id(4);
+    constexpr auto num_values_field_id = thrift::field_id(5);
+    constexpr auto total_uncompressed_size_field_id = thrift::field_id(6);
+    constexpr auto total_compressed_size_field_id = thrift::field_id(7);
+    constexpr auto key_value_metadata_field_id = thrift::field_id(8);
+    constexpr auto data_page_offset_field_id = thrift::field_id(9);
+    constexpr auto index_page_offset_field_id = thrift::field_id(10);
+    constexpr auto dictionary_page_offset_field_id = thrift::field_id(11);
+    constexpr auto stats_field_id = thrift::field_id(12);
+
+    column_meta_data result;
+    thrift::struct_decoder dec(parser);
+    while (auto hdr = dec.read_field_header()) {
+        if (hdr->id == type_field_id) {
+            result.type = decode_physical_type(thrift::decode_i32(parser));
+        } else if (hdr->id == encodings_field_id) {
+            thrift::list_decoder list(parser);
+            for (size_t i = 0; i < list.size(); ++i) {
+                result.encodings.push_back(
+                  static_cast<encoding>(thrift::decode_i32(parser)));
+            }
+        } else if (hdr->id == path_in_schema_field_id) {
+            thrift::list_decoder list(parser);
+            for (size_t i = 0; i < list.size(); ++i) {
+                result.path_in_schema.push_back(thrift::decode_string(parser));
+            }
+        } else if (hdr->id == codec_field_id) {
+            result.codec = static_cast<compression_codec>(
+              thrift::decode_i32(parser));
+        } else if (hdr->id == num_values_field_id) {
+            result.num_values = thrift::decode_i64(parser);
+        } else if (hdr->id == total_uncompressed_size_field_id) {
+            result.total_uncompressed_size = thrift::decode_i64(parser);
+        } else if (hdr->id == total_compressed_size_field_id) {
+            result.total_compressed_size = thrift::decode_i64(parser);
+        } else if (hdr->id == key_value_metadata_field_id) {
+            thrift::list_decoder list(parser);
+            for (size_t i = 0; i < list.size(); ++i) {
+                thrift::struct_decoder kv_dec(parser);
+                ss::sstring key;
+                ss::sstring value;
+                while (auto kv_hdr = kv_dec.read_field_header()) {
+                    if (kv_hdr->id() == 1) {
+                        key = thrift::decode_string(parser);
+                    } else if (kv_hdr->id() == 2) {
+                        value = thrift::decode_string(parser);
+                    } else {
+                        kv_dec.skip_field(kv_hdr->type);
+                    }
+                }
+                result.key_value_metadata.emplace_back(
+                  std::move(key), std::move(value));
+            }
+        } else if (hdr->id == data_page_offset_field_id) {
+            result.data_page_offset = thrift::decode_i64(parser);
+        } else if (hdr->id == index_page_offset_field_id) {
+            result.index_page_offset = thrift::decode_i64(parser);
+        } else if (hdr->id == dictionary_page_offset_field_id) {
+            result.dictionary_page_offset = thrift::decode_i64(parser);
+        } else if (hdr->id == stats_field_id) {
+            result.stats = decode_statistics(parser);
+        } else {
+            dec.skip_field(hdr->type);
+        }
+    }
+    return result;
+}
+
+column_chunk decode_column_chunk(iobuf_parser_base& parser) {
+    constexpr auto file_path_field_id = thrift::field_id(1);
+    // field 2 is deprecated file_offset, skip it
+    constexpr auto meta_data_field_id = thrift::field_id(3);
+
+    column_chunk result;
+    thrift::struct_decoder dec(parser);
+    while (auto hdr = dec.read_field_header()) {
+        if (hdr->id == file_path_field_id) {
+            result.file_path = thrift::decode_string(parser);
+        } else if (hdr->id == meta_data_field_id) {
+            result.meta_data = decode_column_meta_data(parser);
+        } else {
+            dec.skip_field(hdr->type);
+        }
+    }
+    return result;
+}
+
+sorting_column decode_sorting_column(iobuf_parser_base& parser) {
+    sorting_column result;
+    thrift::struct_decoder dec(parser);
+    while (auto hdr = dec.read_field_header()) {
+        switch (hdr->id()) {
+        case 1:
+            result.column_idx = thrift::decode_i32(parser);
+            break;
+        case 2:
+            result.descending = hdr->type == thrift::field_type::boolean_true;
+            break;
+        case 3:
+            result.nulls_first = hdr->type == thrift::field_type::boolean_true;
+            break;
+        default:
+            dec.skip_field(hdr->type);
+            break;
+        }
+    }
+    return result;
+}
+
+row_group decode_row_group(iobuf_parser_base& parser) {
+    constexpr auto columns_field_id = thrift::field_id(1);
+    constexpr auto total_field_id = thrift::field_id(2);
+    constexpr auto num_rows_field_id = thrift::field_id(3);
+    constexpr auto sorting_columns_field_id = thrift::field_id(4);
+    constexpr auto file_offset_field_id = thrift::field_id(5);
+    constexpr auto total_compressed_size_field_id = thrift::field_id(6);
+    constexpr auto ordinal_field_id = thrift::field_id(7);
+
+    row_group result{};
+    thrift::struct_decoder dec(parser);
+    while (auto hdr = dec.read_field_header()) {
+        if (hdr->id == columns_field_id) {
+            thrift::list_decoder list(parser);
+            for (size_t i = 0; i < list.size(); ++i) {
+                result.columns.push_back(decode_column_chunk(parser));
+            }
+        } else if (hdr->id == total_field_id) {
+            result.total_byte_size = thrift::decode_i64(parser);
+        } else if (hdr->id == num_rows_field_id) {
+            result.num_rows = thrift::decode_i64(parser);
+        } else if (hdr->id == sorting_columns_field_id) {
+            thrift::list_decoder list(parser);
+            for (size_t i = 0; i < list.size(); ++i) {
+                result.sorting_columns.push_back(decode_sorting_column(parser));
+            }
+        } else if (hdr->id == file_offset_field_id) {
+            result.file_offset = thrift::decode_i64(parser);
+        } else if (hdr->id == total_compressed_size_field_id) {
+            result.total_compressed_size = thrift::decode_i64(parser);
+        } else if (hdr->id == ordinal_field_id) {
+            result.ordinal = thrift::decode_i16(parser);
+        } else {
+            dec.skip_field(hdr->type);
+        }
+    }
+    return result;
+}
+
+column_order decode_column_order(iobuf_parser_base& parser) {
+    column_order result = column_order::type_defined;
+    thrift::struct_decoder dec(parser);
+    while (auto hdr = dec.read_field_header()) {
+        result = static_cast<column_order>(hdr->id());
+        dec.skip_field(hdr->type);
+    }
+    return result;
+}
+
+data_page_header_v1 decode_data_page_header_v1(iobuf_parser_base& parser) {
+    data_page_header_v1 result{};
+    thrift::struct_decoder dec(parser);
+    while (auto hdr = dec.read_field_header()) {
+        switch (hdr->id()) {
+        case 1:
+            result.num_values = thrift::decode_i32(parser);
+            break;
+        case 2:
+            result.data_encoding = static_cast<encoding>(
+              thrift::decode_i32(parser));
+            break;
+        case 3:
+            result.definition_level_encoding = static_cast<encoding>(
+              thrift::decode_i32(parser));
+            break;
+        case 4:
+            result.repetition_level_encoding = static_cast<encoding>(
+              thrift::decode_i32(parser));
+            break;
+        case 5:
+            result.stats = decode_statistics(parser);
+            break;
+        default:
+            dec.skip_field(hdr->type);
+            break;
+        }
+    }
+    return result;
+}
+
+data_page_header decode_data_page_header(iobuf_parser_base& parser) {
+    data_page_header result{};
+    thrift::struct_decoder dec(parser);
+    while (auto hdr = dec.read_field_header()) {
+        switch (hdr->id()) {
+        case 1:
+            result.num_values = thrift::decode_i32(parser);
+            break;
+        case 2:
+            result.num_nulls = thrift::decode_i32(parser);
+            break;
+        case 3:
+            result.num_rows = thrift::decode_i32(parser);
+            break;
+        case 4:
+            result.data_encoding = static_cast<encoding>(
+              thrift::decode_i32(parser));
+            break;
+        case 5:
+            result.definition_levels_byte_length = thrift::decode_i32(parser);
+            break;
+        case 6:
+            result.repetition_levels_byte_length = thrift::decode_i32(parser);
+            break;
+        case 7:
+            result.is_compressed = hdr->type
+                                   == thrift::field_type::boolean_true;
+            break;
+        case 8:
+            result.stats = decode_statistics(parser);
+            break;
+        default:
+            dec.skip_field(hdr->type);
+            break;
+        }
+    }
+    return result;
+}
+
+dictionary_page_header
+decode_dictionary_page_header(iobuf_parser_base& parser) {
+    dictionary_page_header result{};
+    thrift::struct_decoder dec(parser);
+    while (auto hdr = dec.read_field_header()) {
+        switch (hdr->id()) {
+        case 1:
+            result.num_values = thrift::decode_i32(parser);
+            break;
+        case 2:
+            result.data_encoding = static_cast<encoding>(
+              thrift::decode_i32(parser));
+            break;
+        case 3:
+            result.is_sorted = hdr->type == thrift::field_type::boolean_true;
+            break;
+        default:
+            dec.skip_field(hdr->type);
+            break;
+        }
+    }
+    return result;
+}
+
+} // namespace
+
+page_header decode(iobuf_parser_base& parser, page_header_tag) {
+    constexpr auto type_field_id = thrift::field_id(1);
+    constexpr auto uncompressed_page_size_field_id = thrift::field_id(2);
+    constexpr auto compressed_page_size_field_id = thrift::field_id(3);
+    constexpr auto crc_field_id = thrift::field_id(4);
+    constexpr auto data_page_header_v1_field_id = thrift::field_id(5);
+    constexpr auto index_page_header_field_id = thrift::field_id(6);
+    constexpr auto dictionary_page_header_field_id = thrift::field_id(7);
+    constexpr auto data_page_header_v2_field_id = thrift::field_id(8);
+
+    enum page_type_enum : int32_t {
+        data_page = 0,
+        index_page = 1,
+        dictionary_page = 2,
+        data_page_v2 = 3,
+    };
+
+    page_header result{};
+    thrift::struct_decoder dec(parser);
+    while (auto hdr = dec.read_field_header()) {
+        if (hdr->id == type_field_id) {
+            // Consumed but not directly used — the actual type variant is
+            // set from the type-specific header field below.
+            thrift::decode_i32(parser);
+        } else if (hdr->id == uncompressed_page_size_field_id) {
+            result.uncompressed_page_size = thrift::decode_i32(parser);
+        } else if (hdr->id == compressed_page_size_field_id) {
+            result.compressed_page_size = thrift::decode_i32(parser);
+        } else if (hdr->id == crc_field_id) {
+            result.crc = crc::crc32(
+              static_cast<uint32_t>(thrift::decode_i32(parser)));
+        } else if (hdr->id == data_page_header_v1_field_id) {
+            result.type = decode_data_page_header_v1(parser);
+        } else if (hdr->id == index_page_header_field_id) {
+            result.type = index_page_header{};
+            // Skip the (empty) index page header struct
+            dec.skip_field(hdr->type);
+        } else if (hdr->id == dictionary_page_header_field_id) {
+            result.type = decode_dictionary_page_header(parser);
+        } else if (hdr->id == data_page_header_v2_field_id) {
+            result.type = decode_data_page_header(parser);
+        } else {
+            dec.skip_field(hdr->type);
+        }
+    }
+    return result;
+}
+
+file_metadata decode(iobuf data, file_metadata_tag) {
+    iobuf_parser parser(std::move(data));
+
+    constexpr auto version_field_id = thrift::field_id(1);
+    constexpr auto schema_field_id = thrift::field_id(2);
+    constexpr auto num_rows_field_id = thrift::field_id(3);
+    constexpr auto row_groups_field_id = thrift::field_id(4);
+    constexpr auto key_value_metadata_field_id = thrift::field_id(5);
+    constexpr auto created_by_field_id = thrift::field_id(6);
+    constexpr auto column_orders_field_id = thrift::field_id(7);
+
+    file_metadata result{};
+    thrift::struct_decoder dec(parser);
+    while (auto hdr = dec.read_field_header()) {
+        if (hdr->id == version_field_id) {
+            result.version = thrift::decode_i32(parser);
+        } else if (hdr->id == schema_field_id) {
+            thrift::list_decoder list(parser);
+            bool is_root = true;
+            for (size_t i = 0; i < list.size(); ++i) {
+                result.schema.push_back(
+                  decode_flattened_schema(parser, is_root));
+                is_root = false;
+            }
+        } else if (hdr->id == num_rows_field_id) {
+            result.num_rows = thrift::decode_i64(parser);
+        } else if (hdr->id == row_groups_field_id) {
+            thrift::list_decoder list(parser);
+            for (size_t i = 0; i < list.size(); ++i) {
+                result.row_groups.push_back(decode_row_group(parser));
+            }
+        } else if (hdr->id == key_value_metadata_field_id) {
+            thrift::list_decoder list(parser);
+            for (size_t i = 0; i < list.size(); ++i) {
+                thrift::struct_decoder kv_dec(parser);
+                ss::sstring key;
+                ss::sstring value;
+                while (auto kv_hdr = kv_dec.read_field_header()) {
+                    if (kv_hdr->id() == 1) {
+                        key = thrift::decode_string(parser);
+                    } else if (kv_hdr->id() == 2) {
+                        value = thrift::decode_string(parser);
+                    } else {
+                        kv_dec.skip_field(kv_hdr->type);
+                    }
+                }
+                result.key_value_metadata.emplace_back(
+                  std::move(key), std::move(value));
+            }
+        } else if (hdr->id == created_by_field_id) {
+            result.created_by = thrift::decode_string(parser);
+        } else if (hdr->id == column_orders_field_id) {
+            thrift::list_decoder list(parser);
+            for (size_t i = 0; i < list.size(); ++i) {
+                result.column_orders.push_back(decode_column_order(parser));
+            }
+        } else {
+            dec.skip_field(hdr->type);
+        }
+    }
+    return result;
 }
 
 } // namespace serde::parquet

--- a/src/v/serde/parquet/metadata.cc
+++ b/src/v/serde/parquet/metadata.cc
@@ -1032,8 +1032,7 @@ time_unit decode_time_unit(iobuf_parser_base& parser) {
     return result;
 }
 
-logical_type
-decode_logical_type(iobuf_parser_base& parser, int32_t& out_scale) {
+logical_type decode_logical_type(iobuf_parser_base& parser) {
     enum logical_type_id : int16_t {
         string = 1,
         map = 2,
@@ -1087,7 +1086,6 @@ decode_logical_type(iobuf_parser_base& parser, int32_t& out_scale) {
                     break;
                 }
             }
-            out_scale = dt.scale;
             result = dt;
             break;
         }
@@ -1222,8 +1220,7 @@ decode_flattened_schema(iobuf_parser_base& parser, bool /*is_root*/) {
         } else if (hdr->id == field_id_field_id) {
             result.field_id = thrift::decode_i32(parser);
         } else if (hdr->id == logical_type_field_id) {
-            int32_t scale = 0;
-            result.logical_type = decode_logical_type(parser, scale);
+            result.logical_type = decode_logical_type(parser);
         } else {
             dec.skip_field(hdr->type);
         }

--- a/src/v/serde/parquet/metadata.h
+++ b/src/v/serde/parquet/metadata.h
@@ -27,6 +27,7 @@
 
 #include "base/seastarx.h"
 #include "bytes/iobuf.h"
+#include "bytes/iobuf_parser.h"
 #include "container/chunked_vector.h"
 #include "hashing/crc32.h"
 #include "serde/parquet/flattened_schema.h"
@@ -263,6 +264,16 @@ struct dictionary_page_header {
     bool is_sorted;
 };
 
+/// Data Page V1 header. Used by Arrow, Spark, and most external writers.
+/// In V1 the entire page body (levels + data) is compressed together.
+struct data_page_header_v1 {
+    int32_t num_values = 0;
+    encoding data_encoding = encoding::plain;
+    encoding definition_level_encoding = encoding::rle;
+    encoding repetition_level_encoding = encoding::rle;
+    std::optional<statistics> stats;
+};
+
 /**
  * New page format allowing reading levels without decompressing the data
  * Repetition and definition levels are uncompressed
@@ -332,7 +343,11 @@ struct page_header {
     crc::crc32 crc;
 
     // Headers for page specific data.  One only will be set.
-    std::variant<index_page_header, dictionary_page_header, data_page_header>
+    std::variant<
+      index_page_header,
+      dictionary_page_header,
+      data_page_header,
+      data_page_header_v1>
       type;
 };
 
@@ -341,6 +356,14 @@ struct page_header {
  * format.
  */
 iobuf encode(const page_header& header);
+
+struct page_header_tag {};
+
+/**
+ * Decode a page header from binary Thrift compact format.
+ * The parser position is advanced past the decoded bytes.
+ */
+page_header decode(iobuf_parser_base& parser, page_header_tag);
 
 /**
  * Description for column metadata
@@ -496,5 +519,12 @@ struct file_metadata {
  * format.
  */
 iobuf encode(const file_metadata& metadata);
+
+struct file_metadata_tag {};
+
+/**
+ * Decode file metadata from binary Thrift compact format.
+ */
+file_metadata decode(iobuf data, file_metadata_tag);
 
 } // namespace serde::parquet

--- a/src/v/serde/parquet/metadata.h
+++ b/src/v/serde/parquet/metadata.h
@@ -309,7 +309,7 @@ struct data_page_header {
     definition_levels_byte_length + repetition_levels_byte_length + 1 and
     compressed_page_size (included) is compressed with the compression_codec. If
     missing it is considered compressed */
-    bool is_compressed;
+    bool is_compressed = true;
 
     /** Optional statistics for the data in this page **/
     std::optional<statistics> stats;

--- a/src/v/serde/parquet/reader.cc
+++ b/src/v/serde/parquet/reader.cc
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "serde/parquet/reader.h"
+
+#include "serde/parquet/assembler.h"
+#include "serde/parquet/column_chunk_reader.h"
+#include "serde/parquet/flattened_schema.h"
+
+#include <seastar/coroutine/maybe_yield.hh>
+
+#include <stdexcept>
+
+namespace serde::parquet {
+
+namespace {
+
+// File layout: [PAR1] [row group pages...] [footer (thrift)] [footer_size
+// (4B LE)] [PAR1]
+constexpr size_t magic_size = 4;
+constexpr size_t footer_suffix_size = magic_size + sizeof(uint32_t);
+constexpr std::string_view parquet_magic = "PAR1";
+
+void validate_magic(iobuf& file_data) {
+    auto file_size = file_data.size_bytes();
+    if (file_size < magic_size + footer_suffix_size) {
+        throw std::runtime_error("file too small to be a valid parquet file");
+    }
+    // Check trailing magic
+    auto tail = file_data.share(file_size - magic_size, magic_size);
+    iobuf_parser tail_parser(std::move(tail));
+    auto magic = tail_parser.read_string_unsafe(magic_size);
+    if (magic != parquet_magic) {
+        throw std::runtime_error("invalid parquet file: missing trailing PAR1");
+    }
+}
+
+file_metadata parse_footer(iobuf& file_data) {
+    auto file_size = file_data.size_bytes();
+    // Read footer length (4 bytes LE before trailing PAR1)
+    auto len_region = file_data.share(
+      file_size - footer_suffix_size, sizeof(uint32_t));
+    iobuf_parser len_parser(std::move(len_region));
+    auto footer_len = ss::le_to_cpu(len_parser.consume_type<uint32_t>());
+
+    if (footer_len > file_size - magic_size - footer_suffix_size) {
+        throw std::runtime_error(
+          "invalid parquet file: footer length exceeds "
+          "file size");
+    }
+
+    auto footer_bytes = file_data.share(
+      file_size - footer_suffix_size - footer_len, footer_len);
+    return decode(std::move(footer_bytes), file_metadata_tag{});
+}
+
+/// Resolve which leaf columns to read based on projection paths.
+/// Returns a set of schema positions for projected leaf columns.
+/// If projection is empty, all leaves are included.
+chunked_vector<bool> resolve_projection(
+  const schema_element& schema,
+  const chunked_vector<chunked_vector<ss::sstring>>& projection) {
+    chunked_vector<bool> included;
+    if (projection.empty()) {
+        schema.for_each([&](const schema_element& elem) {
+            if (elem.is_leaf()) {
+                included.push_back(true);
+            }
+        });
+        return included;
+    }
+    // Build inclusion set from projection paths
+    schema.for_each([&](const schema_element& elem) {
+        if (!elem.is_leaf()) {
+            return;
+        }
+        bool match = false;
+        for (const auto& proj_path : projection) {
+            if (elem.path.size() < proj_path.size()) {
+                continue;
+            }
+            bool path_match = true;
+            for (size_t i = 0; i < proj_path.size(); ++i) {
+                // Compare from the end of the path (leaf name matching)
+                auto elem_idx = elem.path.size() - proj_path.size() + i;
+                if (elem.path[elem_idx] != proj_path[i]) {
+                    path_match = false;
+                    break;
+                }
+            }
+            if (path_match) {
+                match = true;
+                break;
+            }
+        }
+        included.push_back(match);
+    });
+    return included;
+}
+
+/// Build a projected schema tree containing only the included leaves
+/// and their ancestor groups. `included` is a bool per leaf in
+/// depth-first order (same as resolve_projection output).
+schema_element project_schema(
+  const schema_element& schema, const chunked_vector<bool>& included) {
+    // Helper: recursively prune. Returns nullopt if no descendants are
+    // included. leaf_idx tracks position in the included vector.
+    struct pruner {
+        const chunked_vector<bool>& included;
+        size_t leaf_idx = 0;
+
+        std::optional<schema_element> prune(const schema_element& node) {
+            if (node.is_leaf()) {
+                bool keep = leaf_idx < included.size() && included[leaf_idx];
+                ++leaf_idx;
+                if (keep) {
+                    return schema_element{
+                      .position = node.position,
+                      .type = node.type,
+                      .repetition_type = node.repetition_type,
+                      .path = node.path.copy(),
+                      .field_id = node.field_id,
+                      .logical_type = node.logical_type,
+                      .max_definition_level = node.max_definition_level,
+                      .max_repetition_level = node.max_repetition_level,
+                    };
+                }
+                return std::nullopt;
+            }
+            chunked_vector<schema_element> kept_children;
+            for (const auto& child : node.children) {
+                auto projected = prune(child);
+                if (projected) {
+                    kept_children.push_back(std::move(*projected));
+                }
+            }
+            if (kept_children.empty()) {
+                return std::nullopt;
+            }
+            return schema_element{
+              .position = node.position,
+              .type = node.type,
+              .repetition_type = node.repetition_type,
+              .path = node.path.copy(),
+              .children = std::move(kept_children),
+              .field_id = node.field_id,
+              .logical_type = node.logical_type,
+              .max_definition_level = node.max_definition_level,
+              .max_repetition_level = node.max_repetition_level,
+            };
+        }
+    };
+
+    pruner p{included};
+    auto result = p.prune(schema);
+    if (result) {
+        return std::move(*result);
+    }
+    return schema_element{};
+}
+
+} // namespace
+
+ss::future<file_reader_result> read_file(iobuf file_data, reader_options opts) {
+    validate_magic(file_data);
+    auto metadata = parse_footer(file_data);
+    auto schema = unflatten(metadata.schema);
+    index_schema(schema);
+
+    auto projection = resolve_projection(schema, opts.column_projection);
+
+    chunked_vector<columnar_batch> row_group_batches;
+    for (const auto& rg : metadata.row_groups) {
+        columnar_batch batch;
+        batch.num_rows = rg.num_rows;
+
+        int32_t leaf_idx = 0;
+        for (const auto& cc : rg.columns) {
+            if (
+              leaf_idx < static_cast<int32_t>(projection.size())
+              && !projection[leaf_idx]) {
+                ++leaf_idx;
+                continue;
+            }
+
+            // Find the schema element for this column.
+            // path_in_schema omits the root name, so we compare from
+            // index 1 of the schema element's path.
+            const schema_element* col_schema = nullptr;
+            schema.for_each([&](const schema_element& elem) {
+                if (!elem.is_leaf()) {
+                    return;
+                }
+                if (
+                  elem.path.size() != cc.meta_data.path_in_schema.size() + 1) {
+                    return;
+                }
+                bool match = true;
+                for (size_t i = 0; i < cc.meta_data.path_in_schema.size();
+                     ++i) {
+                    if (elem.path[i + 1] != cc.meta_data.path_in_schema[i]) {
+                        match = false;
+                        break;
+                    }
+                }
+                if (match) {
+                    col_schema = &elem;
+                }
+            });
+            if (!col_schema) {
+                throw std::runtime_error(
+                  fmt::format(
+                    "schema element not found for column path: {}",
+                    fmt::join(cc.meta_data.path_in_schema, ".")));
+            }
+
+            auto col_bytes = file_data.share(
+              cc.meta_data.data_page_offset,
+              cc.meta_data.total_compressed_size);
+
+            auto col_data = co_await decode_column_chunk(
+              std::move(col_bytes), cc.meta_data, *col_schema);
+
+            batch.columns.push_back(std::move(col_data.values));
+            batch.levels.push_back(
+              columnar_batch::level_data{
+                .def_levels = std::move(col_data.def_levels),
+                .rep_levels = std::move(col_data.rep_levels),
+              });
+            ++leaf_idx;
+        }
+
+        row_group_batches.push_back(std::move(batch));
+        co_await ss::coroutine::maybe_yield();
+    }
+
+    // Return a projected schema that matches the batch columns, so
+    // callers (including assemble_records) see a coherent pair.
+    auto result_schema = opts.column_projection.empty()
+                           ? std::move(schema)
+                           : project_schema(schema, projection);
+
+    co_return file_reader_result{
+      .metadata = std::move(metadata),
+      .schema = std::move(result_schema),
+      .row_groups = std::move(row_group_batches),
+    };
+}
+
+ss::future<chunked_vector<group_value>>
+read_file_as_records(iobuf file_data, reader_options opts) {
+    auto result = co_await read_file(std::move(file_data), std::move(opts));
+
+    chunked_vector<group_value> all_records;
+    for (const auto& batch : result.row_groups) {
+        auto records = assemble_records(result.schema, batch);
+        for (auto& rec : records) {
+            all_records.push_back(std::move(rec));
+        }
+        co_await ss::coroutine::maybe_yield();
+    }
+    co_return all_records;
+}
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/reader.h
+++ b/src/v/serde/parquet/reader.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "serde/parquet/column_array.h"
+#include "serde/parquet/metadata.h"
+#include "serde/parquet/value.h"
+
+#include <seastar/core/future.hh>
+
+namespace serde::parquet {
+
+struct reader_options {
+    /// Column paths to read (projection pushdown). Empty = all columns.
+    chunked_vector<chunked_vector<ss::sstring>> column_projection;
+};
+
+struct file_reader_result {
+    /// Full file metadata from the parquet footer.
+    file_metadata metadata;
+    /// Schema matching the columns in row_groups. When column_projection
+    /// is used, this is a pruned schema containing only the projected
+    /// leaves and their ancestor groups.
+    schema_element schema;
+    chunked_vector<columnar_batch> row_groups;
+};
+
+/// \brief Read a complete parquet file from an iobuf.
+///
+/// Parses the footer, recovers the schema, decodes column chunks (async
+/// for decompression), and returns columnar batches per row group.
+ss::future<file_reader_result>
+read_file(iobuf file_data, reader_options opts = {});
+
+/// \brief Read a parquet file and assemble records.
+///
+/// Convenience wrapper that calls read_file() then assembles all row
+/// groups into group_value records using the record assembler.
+ss::future<chunked_vector<group_value>>
+read_file_as_records(iobuf file_data, reader_options opts = {});
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/tests/BUILD
+++ b/src/v/serde/parquet/tests/BUILD
@@ -5,6 +5,39 @@ load("//bazel:build.bzl", "redpanda_cc_binary")
 load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_gtest")
 
 redpanda_cc_gtest(
+    name = "metadata_roundtrip_test",
+    timeout = "short",
+    srcs = [
+        "metadata_roundtrip_test.cc",
+    ],
+    cpu = 1,
+    memory = "128MiB",
+    deps = [
+        "//src/v/serde/parquet:metadata",
+        "//src/v/serde/parquet:schema",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "flattened_schema_test",
+    timeout = "short",
+    srcs = [
+        "flattened_schema_test.cc",
+    ],
+    cpu = 1,
+    memory = "64MiB",
+    deps = [
+        "//src/v/serde/parquet:schema",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "value_test",
     timeout = "short",
     srcs = [

--- a/src/v/serde/parquet/tests/BUILD
+++ b/src/v/serde/parquet/tests/BUILD
@@ -5,6 +5,27 @@ load("//bazel:build.bzl", "redpanda_cc_binary")
 load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_gtest")
 
 redpanda_cc_gtest(
+    name = "assembler_test",
+    timeout = "short",
+    srcs = [
+        "assembler_test.cc",
+    ],
+    cpu = 1,
+    memory = "128MiB",
+    deps = [
+        "//src/v/serde/parquet:assembler",
+        "//src/v/serde/parquet:column_array",
+        "//src/v/serde/parquet:encoding",
+        "//src/v/serde/parquet:schema",
+        "//src/v/serde/parquet:shredder",
+        "//src/v/serde/parquet:value",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "column_chunk_reader_test",
     timeout = "short",
     srcs = [

--- a/src/v/serde/parquet/tests/BUILD
+++ b/src/v/serde/parquet/tests/BUILD
@@ -5,6 +5,45 @@ load("//bazel:build.bzl", "redpanda_cc_binary")
 load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_gtest")
 
 redpanda_cc_gtest(
+    name = "column_chunk_reader_test",
+    timeout = "short",
+    srcs = [
+        "column_chunk_reader_test.cc",
+    ],
+    cpu = 1,
+    memory = "128MiB",
+    deps = [
+        "//src/v/bytes:iostream",
+        "//src/v/serde/parquet:column_chunk_reader",
+        "//src/v/serde/parquet:column_writer",
+        "//src/v/serde/parquet:encoding",
+        "//src/v/serde/parquet:metadata",
+        "//src/v/serde/parquet:schema",
+        "//src/v/serde/parquet:value",
+        "//src/v/serde/parquet:writer",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "column_array_test",
+    timeout = "short",
+    srcs = [
+        "column_array_test.cc",
+    ],
+    cpu = 1,
+    memory = "64MiB",
+    deps = [
+        "//src/v/serde/parquet:column_array",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "metadata_roundtrip_test",
     timeout = "short",
     srcs = [

--- a/src/v/serde/parquet/tests/BUILD
+++ b/src/v/serde/parquet/tests/BUILD
@@ -5,6 +5,26 @@ load("//bazel:build.bzl", "redpanda_cc_binary")
 load("//bazel:test.bzl", "redpanda_cc_bench", "redpanda_cc_gtest")
 
 redpanda_cc_gtest(
+    name = "reader_test",
+    timeout = "short",
+    srcs = [
+        "reader_test.cc",
+    ],
+    cpu = 1,
+    memory = "128MiB",
+    deps = [
+        "//src/v/bytes:iostream",
+        "//src/v/serde/parquet:reader",
+        "//src/v/serde/parquet:schema",
+        "//src/v/serde/parquet:value",
+        "//src/v/serde/parquet:writer",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "assembler_test",
     timeout = "short",
     srcs = [

--- a/src/v/serde/parquet/tests/assembler_test.cc
+++ b/src/v/serde/parquet/tests/assembler_test.cc
@@ -1,0 +1,336 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "serde/parquet/assembler.h"
+#include "serde/parquet/column_array.h"
+#include "serde/parquet/encoding.h"
+#include "serde/parquet/schema.h"
+#include "serde/parquet/shredder.h"
+#include "serde/parquet/value.h"
+
+#include <seastar/util/variant_utils.hh>
+
+#include <gtest/gtest.h>
+
+#include <climits>
+
+namespace serde::parquet {
+
+namespace {
+
+template<typename... Args>
+schema_element
+group_node(ss::sstring name, field_repetition_type rep_type, Args... args) {
+    chunked_vector<schema_element> children;
+    (children.push_back(std::move(args)), ...);
+    return {
+      .type = std::monostate{},
+      .repetition_type = rep_type,
+      .path = {std::move(name)},
+      .children = std::move(children),
+    };
+}
+
+schema_element leaf_node(
+  ss::sstring name,
+  field_repetition_type rep_type,
+  physical_type ptype,
+  logical_type ltype = logical_type{}) {
+    return {
+      .type = ptype,
+      .repetition_type = rep_type,
+      .path = {std::move(name)},
+      .logical_type = ltype,
+    };
+}
+
+template<typename... Args>
+group_value record(Args... field) {
+    chunked_vector<group_member> fields;
+    (fields.push_back(group_member{std::move(field)}), ...);
+    return fields;
+}
+
+template<typename... Args>
+repeated_value list(Args... field) {
+    chunked_vector<repeated_element> fields;
+    (fields.push_back(repeated_element{std::move(field)}), ...);
+    return fields;
+}
+
+/// Shred records into a columnar_batch suitable for the assembler.
+/// Consumes the schema (moves it into the batch).
+columnar_batch
+shred_to_batch(schema_element& schema, chunked_vector<group_value>& rows) {
+    index_schema(schema);
+
+    // Collect per-leaf column data
+    struct leaf_data {
+        chunked_vector<value> values;
+        chunked_vector<def_level> def_levels;
+        chunked_vector<rep_level> rep_levels;
+    };
+
+    // Map from schema position to leaf index
+    chunked_vector<int32_t> pos_to_leaf;
+    chunked_vector<leaf_data> leaves;
+    int32_t max_pos = 0;
+    schema.for_each([&](const schema_element& elem) {
+        max_pos = std::max(max_pos, elem.position);
+    });
+    for (int32_t i = 0; i <= max_pos; ++i) {
+        pos_to_leaf.push_back(-1);
+    }
+    schema.for_each([&](const schema_element& elem) {
+        if (!elem.is_leaf()) {
+            return;
+        }
+        pos_to_leaf[elem.position] = static_cast<int32_t>(leaves.size());
+        leaves.emplace_back();
+    });
+
+    for (auto& row : rows) {
+        auto row_copy = std::get<group_value>(copy(value(std::move(row))));
+        shred_record(schema, std::move(row_copy), [&](shredded_value sv) {
+            auto leaf_idx = pos_to_leaf[sv.schema_element_position];
+            auto& ld = leaves[leaf_idx];
+            ld.values.push_back(std::move(sv.val));
+            ld.def_levels.push_back(sv.def_level);
+            ld.rep_levels.push_back(sv.rep_level);
+            return ss::make_ready_future();
+        }).get();
+    }
+
+    // Build the columnar_batch from the shredded data
+    columnar_batch batch;
+    batch.num_rows = static_cast<int64_t>(rows.size());
+
+    int32_t leaf_idx = 0;
+    schema.for_each([&](const schema_element& elem) {
+        if (!elem.is_leaf()) {
+            return;
+        }
+        auto& ld = leaves[leaf_idx];
+
+        column_array arr;
+        arr.ptype = elem.type;
+        arr.ltype = elem.logical_type;
+        arr.length = static_cast<int64_t>(ld.values.size());
+
+        // Build the data based on physical type, collecting non-null values
+        ss::visit(
+          elem.type,
+          [&](const bool_type&) {
+              auto& d = arr.data.emplace<column_array::boolean_data>();
+              uint8_t current_byte = 0;
+              for (auto& v : ld.values) {
+                  if (auto* bv = std::get_if<boolean_value>(&v)) {
+                      current_byte |= static_cast<uint8_t>(bv->val)
+                                      << (d.num_values % CHAR_BIT);
+                      ++d.num_values;
+                      if (d.num_values % CHAR_BIT == 0) {
+                          d.packed_bits.append(&current_byte, 1);
+                          current_byte = 0;
+                      }
+                  }
+              }
+              if (d.num_values % CHAR_BIT != 0) {
+                  d.packed_bits.append(&current_byte, 1);
+              }
+          },
+          [&](const i32_type&) {
+              auto& d = arr.data.emplace<column_array::i32_data>();
+              for (auto& v : ld.values) {
+                  if (auto* iv = std::get_if<int32_value>(&v)) {
+                      d.values.push_back(iv->val);
+                  }
+              }
+          },
+          [&](const i64_type&) {
+              auto& d = arr.data.emplace<column_array::i64_data>();
+              for (auto& v : ld.values) {
+                  if (auto* iv = std::get_if<int64_value>(&v)) {
+                      d.values.push_back(iv->val);
+                  }
+              }
+          },
+          [&](const f32_type&) {
+              auto& d = arr.data.emplace<column_array::f32_data>();
+              for (auto& v : ld.values) {
+                  if (auto* fv = std::get_if<float32_value>(&v)) {
+                      d.values.push_back(fv->val);
+                  }
+              }
+          },
+          [&](const f64_type&) {
+              auto& d = arr.data.emplace<column_array::f64_data>();
+              for (auto& v : ld.values) {
+                  if (auto* fv = std::get_if<float64_value>(&v)) {
+                      d.values.push_back(fv->val);
+                  }
+              }
+          },
+          [&](const byte_array_type& t) {
+              if (t.fixed_length.has_value()) {
+                  auto& d
+                    = arr.data.emplace<column_array::fixed_byte_array_data>();
+                  d.fixed_length = *t.fixed_length;
+                  for (auto& v : ld.values) {
+                      if (auto* bav = std::get_if<fixed_byte_array_value>(&v)) {
+                          d.data.append(bav->val.copy());
+                      }
+                  }
+              } else {
+                  auto& d = arr.data.emplace<column_array::byte_array_data>();
+                  d.offsets.push_back(0);
+                  int64_t offset = 0;
+                  for (auto& v : ld.values) {
+                      if (auto* bav = std::get_if<byte_array_value>(&v)) {
+                          auto len = static_cast<int64_t>(
+                            bav->val.size_bytes());
+                          d.data.append(bav->val.copy());
+                          offset += len;
+                          d.offsets.push_back(offset);
+                      }
+                  }
+              }
+          },
+          [&](const std::monostate&) {
+              arr.data.emplace<column_array::boolean_data>();
+          });
+
+        batch.columns.push_back(std::move(arr));
+        batch.levels.push_back(
+          columnar_batch::level_data{
+            .def_levels = std::move(ld.def_levels),
+            .rep_levels = std::move(ld.rep_levels),
+          });
+        ++leaf_idx;
+    });
+
+    return batch;
+}
+
+/// Shred-then-assemble consumes rows (via move), so we need to build
+/// the expected values upfront. Since group_value uses chunked_vector
+/// (not copyable), we compare assembled results against freshly
+/// constructed expected values in each test.
+
+} // namespace
+
+// NOLINTBEGIN(*magic-number*)
+
+TEST(Assembler, FlatRequired) {
+    using field_repetition_type::required;
+    auto schema = group_node(
+      "schema",
+      required,
+      leaf_node("a", required, i32_type()),
+      leaf_node("b", required, i64_type()));
+
+    chunked_vector<group_value> rows;
+    rows.push_back(record(int32_value{1}, int64_value{10}));
+    rows.push_back(record(int32_value{2}, int64_value{20}));
+    rows.push_back(record(int32_value{3}, int64_value{30}));
+
+    auto batch = shred_to_batch(schema, rows);
+    auto result = assemble_records(schema, batch);
+
+    ASSERT_EQ(result.size(), 3);
+    EXPECT_EQ(result[0], record(int32_value{1}, int64_value{10}));
+    EXPECT_EQ(result[1], record(int32_value{2}, int64_value{20}));
+    EXPECT_EQ(result[2], record(int32_value{3}, int64_value{30}));
+}
+
+TEST(Assembler, FlatOptional) {
+    using field_repetition_type::optional;
+    using field_repetition_type::required;
+    auto schema = group_node(
+      "schema",
+      required,
+      leaf_node("a", optional, i32_type()),
+      leaf_node("b", optional, i64_type()));
+
+    chunked_vector<group_value> rows;
+    rows.push_back(record(int32_value{1}, null_value{}));
+    rows.push_back(record(null_value{}, int64_value{20}));
+    rows.push_back(record(int32_value{3}, int64_value{30}));
+
+    auto batch = shred_to_batch(schema, rows);
+    auto result = assemble_records(schema, batch);
+
+    ASSERT_EQ(result.size(), 3);
+    EXPECT_EQ(result[0], record(int32_value{1}, null_value{}));
+    EXPECT_EQ(result[1], record(null_value{}, int64_value{20}));
+    EXPECT_EQ(result[2], record(int32_value{3}, int64_value{30}));
+}
+
+TEST(Assembler, NestedOptionalGroup) {
+    using field_repetition_type::optional;
+    using field_repetition_type::required;
+    auto schema = group_node(
+      "schema",
+      required,
+      group_node(
+        "inner",
+        optional,
+        leaf_node("x", required, i32_type()),
+        leaf_node("y", required, i32_type())),
+      leaf_node("z", required, i64_type()));
+
+    chunked_vector<group_value> rows;
+    rows.push_back(
+      record(value(record(int32_value{1}, int32_value{2})), int64_value{100}));
+    rows.push_back(record(null_value{}, int64_value{200}));
+    rows.push_back(
+      record(value(record(int32_value{5}, int32_value{6})), int64_value{300}));
+
+    auto batch = shred_to_batch(schema, rows);
+    auto result = assemble_records(schema, batch);
+
+    ASSERT_EQ(result.size(), 3);
+    EXPECT_EQ(
+      result[0],
+      record(value(record(int32_value{1}, int32_value{2})), int64_value{100}));
+    EXPECT_EQ(result[1], record(null_value{}, int64_value{200}));
+    EXPECT_EQ(
+      result[2],
+      record(value(record(int32_value{5}, int32_value{6})), int64_value{300}));
+}
+
+TEST(Assembler, RepeatedLeaf) {
+    using field_repetition_type::repeated;
+    using field_repetition_type::required;
+    auto schema = group_node(
+      "schema", required, leaf_node("vals", repeated, i32_type()));
+
+    chunked_vector<group_value> rows;
+    rows.push_back(record(value(list(
+      value(int32_value{1}), value(int32_value{2}), value(int32_value{3})))));
+    rows.push_back(
+      record(value(list(value(int32_value{10}), value(int32_value{20})))));
+
+    auto batch = shred_to_batch(schema, rows);
+    auto result = assemble_records(schema, batch);
+
+    ASSERT_EQ(result.size(), 2);
+    EXPECT_EQ(
+      result[0],
+      record(value(list(
+        value(int32_value{1}), value(int32_value{2}), value(int32_value{3})))));
+    EXPECT_EQ(
+      result[1],
+      record(value(list(value(int32_value{10}), value(int32_value{20})))));
+}
+
+// NOLINTEND(*magic-number*)
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/tests/column_array_test.cc
+++ b/src/v/serde/parquet/tests/column_array_test.cc
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "serde/parquet/column_array.h"
+
+#include <gtest/gtest.h>
+
+using namespace serde::parquet;
+
+TEST(ColumnArray, I32Construction) {
+    column_array arr;
+    arr.ptype = i32_type();
+    arr.length = 3;
+    auto& d = arr.data.emplace<column_array::i32_data>();
+    d.values.push_back(10);
+    d.values.push_back(20);
+    d.values.push_back(30);
+    EXPECT_EQ(arr.length, 3);
+    auto* i32d = std::get_if<column_array::i32_data>(&arr.data);
+    ASSERT_NE(i32d, nullptr);
+    EXPECT_EQ(i32d->values.size(), 3);
+    EXPECT_EQ(i32d->values[0], 10);
+}
+
+TEST(ColumnarBatch, Construction) {
+    columnar_batch batch;
+    batch.num_rows = 100;
+
+    column_array col;
+    col.ptype = i64_type();
+    col.length = 100;
+    col.data.emplace<column_array::i64_data>();
+    batch.columns.push_back(std::move(col));
+
+    columnar_batch::level_data ld;
+    batch.levels.push_back(std::move(ld));
+
+    EXPECT_EQ(batch.num_rows, 100);
+    EXPECT_EQ(batch.columns.size(), 1);
+    EXPECT_EQ(batch.levels.size(), 1);
+}

--- a/src/v/serde/parquet/tests/column_chunk_reader_test.cc
+++ b/src/v/serde/parquet/tests/column_chunk_reader_test.cc
@@ -1,0 +1,465 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "bytes/iostream.h"
+#include "serde/parquet/column_chunk_reader.h"
+#include "serde/parquet/encoding.h"
+#include "serde/parquet/metadata.h"
+#include "serde/parquet/schema.h"
+#include "serde/parquet/value.h"
+#include "serde/parquet/writer.h"
+
+#include <gtest/gtest.h>
+
+namespace serde::parquet {
+
+namespace {
+
+schema_element make_schema(
+  ss::sstring col_name,
+  field_repetition_type rep,
+  physical_type ptype,
+  logical_type ltype = {}) {
+    chunked_vector<schema_element> children;
+    children.push_back(
+      schema_element{
+        .type = ptype,
+        .repetition_type = rep,
+        .path = {std::move(col_name)},
+        .logical_type = ltype,
+      });
+    return {
+      .repetition_type = field_repetition_type::required,
+      .path = {"root"},
+      .children = std::move(children),
+    };
+}
+
+struct written_file {
+    iobuf data;
+    file_metadata metadata;
+};
+
+written_file write_simple_file(
+  schema_element schema,
+  chunked_vector<group_value> rows,
+  bool compress = false) {
+    iobuf file;
+    writer w(
+      {.schema = std::move(schema), .compress = compress},
+      make_iobuf_ref_output_stream(file));
+    w.init().get();
+    for (auto& row : rows) {
+        w.write_row(std::move(row)).get();
+    }
+    w.close().get();
+
+    // Parse footer to get metadata
+    auto file_size = file.size_bytes();
+    // Footer layout: [metadata] [4-byte footer len LE] [PAR1]
+    auto footer_region = file.share(file_size - 8, 8);
+    iobuf_parser footer_parser(std::move(footer_region));
+    auto footer_len = ss::le_to_cpu(footer_parser.consume_type<int32_t>());
+
+    auto metadata_bytes = file.share(file_size - 8 - footer_len, footer_len);
+    auto metadata = decode(std::move(metadata_bytes), file_metadata_tag{});
+
+    return {std::move(file), std::move(metadata)};
+}
+
+iobuf extract_column_bytes(iobuf& file, const column_meta_data& col_meta) {
+    return file.share(
+      col_meta.data_page_offset, col_meta.total_compressed_size);
+}
+
+} // namespace
+
+// NOLINTBEGIN(*magic-number*)
+
+TEST(ColumnChunkReader, RequiredInt32) {
+    chunked_vector<group_value> rows;
+    for (int i = 0; i < 10; ++i) {
+        group_value row;
+        row.push_back(group_member{int32_value{i * 10}});
+        rows.push_back(std::move(row));
+    }
+    auto [file, metadata] = write_simple_file(
+      make_schema("val", field_repetition_type::required, i32_type()),
+      std::move(rows));
+
+    // Reconstruct schema for the decoder
+    auto schema = make_schema(
+      "val", field_repetition_type::required, i32_type());
+    index_schema(schema);
+    const auto& col_meta = metadata.row_groups[0].columns[0].meta_data;
+    auto col_bytes = extract_column_bytes(file, col_meta);
+    auto result = decode_column_chunk(
+                    std::move(col_bytes), col_meta, schema.children[0])
+                    .get();
+
+    EXPECT_EQ(result.values.length, 10);
+    auto* i32d = std::get_if<column_array::i32_data>(&result.values.data);
+    ASSERT_NE(i32d, nullptr);
+    ASSERT_EQ(i32d->values.size(), 10);
+    for (int i = 0; i < 10; ++i) {
+        EXPECT_EQ(i32d->values[i], i * 10);
+    }
+}
+
+TEST(ColumnChunkReader, OptionalInt64) {
+    chunked_vector<group_value> rows;
+    for (int i = 0; i < 5; ++i) {
+        group_value row;
+        if (i % 2 == 0) {
+            row.push_back(group_member{int64_value{i * 100}});
+        } else {
+            row.push_back(group_member{null_value{}});
+        }
+        rows.push_back(std::move(row));
+    }
+    auto [file, metadata] = write_simple_file(
+      make_schema("val", field_repetition_type::optional, i64_type()),
+      std::move(rows));
+
+    auto schema = make_schema(
+      "val", field_repetition_type::optional, i64_type());
+    index_schema(schema);
+    const auto& col_meta = metadata.row_groups[0].columns[0].meta_data;
+    auto col_bytes = extract_column_bytes(file, col_meta);
+    auto result = decode_column_chunk(
+                    std::move(col_bytes), col_meta, schema.children[0])
+                    .get();
+
+    EXPECT_EQ(result.values.length, 5);
+    // Null positions tracked via def levels, not a bitmap
+    ASSERT_EQ(result.def_levels.size(), 5);
+    EXPECT_EQ(result.def_levels[0], def_level(1)); // non-null
+    EXPECT_EQ(result.def_levels[1], def_level(0)); // null
+    EXPECT_EQ(result.def_levels[2], def_level(1)); // non-null
+    EXPECT_EQ(result.def_levels[3], def_level(0)); // null
+    EXPECT_EQ(result.def_levels[4], def_level(1)); // non-null
+
+    auto* i64d = std::get_if<column_array::i64_data>(&result.values.data);
+    ASSERT_NE(i64d, nullptr);
+    ASSERT_EQ(i64d->values.size(), 3);
+    EXPECT_EQ(i64d->values[0], 0);
+    EXPECT_EQ(i64d->values[1], 200);
+    EXPECT_EQ(i64d->values[2], 400);
+}
+
+TEST(ColumnChunkReader, RequiredInt32Compressed) {
+    chunked_vector<group_value> rows;
+    for (int i = 0; i < 20; ++i) {
+        group_value row;
+        row.push_back(group_member{int32_value{i}});
+        rows.push_back(std::move(row));
+    }
+    auto [file, metadata] = write_simple_file(
+      make_schema("val", field_repetition_type::required, i32_type()),
+      std::move(rows),
+      /*compress=*/true);
+
+    auto schema = make_schema(
+      "val", field_repetition_type::required, i32_type());
+    index_schema(schema);
+    const auto& col_meta = metadata.row_groups[0].columns[0].meta_data;
+    EXPECT_EQ(col_meta.codec, compression_codec::zstd);
+    auto col_bytes = extract_column_bytes(file, col_meta);
+    auto result = decode_column_chunk(
+                    std::move(col_bytes), col_meta, schema.children[0])
+                    .get();
+
+    EXPECT_EQ(result.values.length, 20);
+    auto* i32d = std::get_if<column_array::i32_data>(&result.values.data);
+    ASSERT_NE(i32d, nullptr);
+    ASSERT_EQ(i32d->values.size(), 20);
+    for (int i = 0; i < 20; ++i) {
+        EXPECT_EQ(i32d->values[i], i);
+    }
+}
+
+TEST(ColumnChunkReader, RequiredByteArray) {
+    chunked_vector<group_value> rows;
+    for (int i = 0; i < 5; ++i) {
+        group_value row;
+        row.push_back(
+          group_member{
+            byte_array_value{iobuf::from(fmt::format("str_{}", i))}});
+        rows.push_back(std::move(row));
+    }
+    auto [file, metadata] = write_simple_file(
+      make_schema(
+        "val",
+        field_repetition_type::required,
+        byte_array_type{},
+        string_type{}),
+      std::move(rows));
+
+    auto schema = make_schema(
+      "val", field_repetition_type::required, byte_array_type{}, string_type{});
+    index_schema(schema);
+    const auto& col_meta = metadata.row_groups[0].columns[0].meta_data;
+    auto col_bytes = extract_column_bytes(file, col_meta);
+    auto result = decode_column_chunk(
+                    std::move(col_bytes), col_meta, schema.children[0])
+                    .get();
+
+    EXPECT_EQ(result.values.length, 5);
+    auto* bad = std::get_if<column_array::byte_array_data>(&result.values.data);
+    ASSERT_NE(bad, nullptr);
+    ASSERT_EQ(bad->offsets.size(), 6);
+    EXPECT_EQ(bad->offsets[0], 0);
+}
+
+// Hand-craft a column chunk with a dictionary page + dictionary-encoded
+// V2 data page. The dictionary holds PLAIN-encoded i32 values; the data
+// page stores RLE-encoded indices.
+TEST(ColumnChunkReader, DictionaryEncodedInt32V2) {
+    constexpr int32_t num_values = 8;
+    // Dictionary: [100, 200, 300]
+    plain_encoder<int32_value> dict_enc;
+    dict_enc.add_value(int32_value{100});
+    dict_enc.add_value(int32_value{200});
+    dict_enc.add_value(int32_value{300});
+    iobuf dict_data = dict_enc.get_encoded_buf();
+    auto dict_data_size = static_cast<int32_t>(dict_data.size_bytes());
+
+    page_header dict_hdr{
+      .uncompressed_page_size = dict_data_size,
+      .compressed_page_size = dict_data_size,
+      .type = dictionary_page_header{
+        .num_values = 3,
+        .data_encoding = encoding::plain,
+      },
+    };
+    iobuf dict_page = encode(dict_hdr);
+    dict_page.append(std::move(dict_data));
+
+    // Data page: indices [0,1,2,0,1,2,0,1] encoded as RLE/bitpack.
+    // bit_width=2 is enough for max index 2.
+    chunked_vector<rep_level> index_levels;
+    for (auto idx : {0, 1, 2, 0, 1, 2, 0, 1}) {
+        index_levels.push_back(rep_level(idx));
+    }
+    // encode_levels produces the same RLE/bitpack wire format.
+    iobuf index_rle = encode_levels(rep_level(2), index_levels);
+    // Prepend the bit_width byte.
+    iobuf data_section;
+    uint8_t bit_width = 2;
+    data_section.append(&bit_width, 1);
+    data_section.append(std::move(index_rle));
+    auto data_section_size = static_cast<int32_t>(data_section.size_bytes());
+
+    page_header data_hdr{
+      .uncompressed_page_size = data_section_size,
+      .compressed_page_size = data_section_size,
+      .type = data_page_header{
+        .num_values = num_values,
+        .num_nulls = 0,
+        .num_rows = num_values,
+        .data_encoding = encoding::rle_dictionary,
+        .definition_levels_byte_length = 0,
+        .repetition_levels_byte_length = 0,
+        .is_compressed = false,
+      },
+    };
+    iobuf data_page = encode(data_hdr);
+    data_page.append(std::move(data_section));
+
+    iobuf chunk;
+    chunk.append(std::move(dict_page));
+    chunk.append(std::move(data_page));
+
+    column_meta_data col_meta{
+      .codec = compression_codec::uncompressed,
+      .num_values = num_values,
+      .total_uncompressed_size = static_cast<int64_t>(chunk.size_bytes()),
+      .total_compressed_size = static_cast<int64_t>(chunk.size_bytes()),
+      .data_page_offset = 0,
+    };
+    auto schema = make_schema(
+      "val", field_repetition_type::required, i32_type());
+    index_schema(schema);
+
+    auto result = decode_column_chunk(
+                    std::move(chunk), col_meta, schema.children[0])
+                    .get();
+
+    EXPECT_EQ(result.values.length, num_values);
+    auto* i32d = std::get_if<column_array::i32_data>(&result.values.data);
+    ASSERT_NE(i32d, nullptr);
+    ASSERT_EQ(i32d->values.size(), num_values);
+    // Expected: dict[0]=100, dict[1]=200, dict[2]=300, repeat...
+    EXPECT_EQ(i32d->values[0], 100);
+    EXPECT_EQ(i32d->values[1], 200);
+    EXPECT_EQ(i32d->values[2], 300);
+    EXPECT_EQ(i32d->values[3], 100);
+    EXPECT_EQ(i32d->values[4], 200);
+    EXPECT_EQ(i32d->values[5], 300);
+    EXPECT_EQ(i32d->values[6], 100);
+    EXPECT_EQ(i32d->values[7], 200);
+}
+
+// Hand-craft a V1 data page with uncompressed body containing
+// 4-byte-prefixed def levels + PLAIN data.
+TEST(ColumnChunkReader, DataPageV1OptionalInt32) {
+    constexpr int32_t num_values = 5;
+    // def levels: [1, 0, 1, 0, 1] -> 3 non-null, 2 null
+    chunked_vector<def_level> def_levels;
+    def_levels.push_back(def_level(1));
+    def_levels.push_back(def_level(0));
+    def_levels.push_back(def_level(1));
+    def_levels.push_back(def_level(0));
+    def_levels.push_back(def_level(1));
+    iobuf encoded_defs = encode_levels(def_level(1), def_levels);
+    auto def_len = static_cast<int32_t>(encoded_defs.size_bytes());
+
+    // PLAIN-encoded data: 3 non-null i32 values [10, 30, 50]
+    plain_encoder<int32_value> data_enc;
+    data_enc.add_value(int32_value{10});
+    data_enc.add_value(int32_value{30});
+    data_enc.add_value(int32_value{50});
+    iobuf data_buf = data_enc.get_encoded_buf();
+
+    // Build the V1 page body: [4-byte def_len LE] [def levels] [data]
+    iobuf body;
+    auto def_len_le = ss::cpu_to_le(def_len);
+    body.append(reinterpret_cast<const char*>(&def_len_le), sizeof(def_len_le));
+    body.append(std::move(encoded_defs));
+    body.append(std::move(data_buf));
+    auto body_size = static_cast<int32_t>(body.size_bytes());
+
+    page_header v1_hdr{
+      .uncompressed_page_size = body_size,
+      .compressed_page_size = body_size,
+      .type = data_page_header_v1{
+        .num_values = num_values,
+        .data_encoding = encoding::plain,
+        .definition_level_encoding = encoding::rle,
+        .repetition_level_encoding = encoding::rle,
+      },
+    };
+    iobuf chunk = encode(v1_hdr);
+    chunk.append(std::move(body));
+
+    column_meta_data col_meta{
+      .codec = compression_codec::uncompressed,
+      .num_values = num_values,
+      .total_uncompressed_size = static_cast<int64_t>(chunk.size_bytes()),
+      .total_compressed_size = static_cast<int64_t>(chunk.size_bytes()),
+      .data_page_offset = 0,
+    };
+    auto schema = make_schema(
+      "val", field_repetition_type::optional, i32_type());
+    index_schema(schema);
+
+    auto result = decode_column_chunk(
+                    std::move(chunk), col_meta, schema.children[0])
+                    .get();
+
+    EXPECT_EQ(result.values.length, num_values);
+    ASSERT_EQ(result.def_levels.size(), num_values);
+    EXPECT_EQ(result.def_levels[0], def_level(1));
+    EXPECT_EQ(result.def_levels[1], def_level(0));
+    EXPECT_EQ(result.def_levels[2], def_level(1));
+    EXPECT_EQ(result.def_levels[3], def_level(0));
+    EXPECT_EQ(result.def_levels[4], def_level(1));
+
+    auto* i32d = std::get_if<column_array::i32_data>(&result.values.data);
+    ASSERT_NE(i32d, nullptr);
+    ASSERT_EQ(i32d->values.size(), 3);
+    EXPECT_EQ(i32d->values[0], 10);
+    EXPECT_EQ(i32d->values[1], 30);
+    EXPECT_EQ(i32d->values[2], 50);
+}
+
+// V1 page with dictionary encoding.
+TEST(ColumnChunkReader, DictionaryEncodedV1) {
+    constexpr int32_t num_values = 4;
+    // Dictionary: [42, 99]
+    plain_encoder<int32_value> dict_enc;
+    dict_enc.add_value(int32_value{42});
+    dict_enc.add_value(int32_value{99});
+    iobuf dict_data = dict_enc.get_encoded_buf();
+    auto dict_data_size = static_cast<int32_t>(dict_data.size_bytes());
+
+    page_header dict_hdr{
+      .uncompressed_page_size = dict_data_size,
+      .compressed_page_size = dict_data_size,
+      .type = dictionary_page_header{
+        .num_values = 2,
+        .data_encoding = encoding::plain,
+      },
+    };
+    iobuf dict_page = encode(dict_hdr);
+    dict_page.append(std::move(dict_data));
+
+    // Indices [0, 1, 1, 0] as RLE
+    chunked_vector<rep_level> index_levels;
+    index_levels.push_back(rep_level(0));
+    index_levels.push_back(rep_level(1));
+    index_levels.push_back(rep_level(1));
+    index_levels.push_back(rep_level(0));
+    iobuf index_rle = encode_levels(rep_level(1), index_levels);
+
+    // V1 body for required column: no rep/def levels, just data.
+    // Data section: [bit_width byte] [RLE indices]
+    iobuf body;
+    uint8_t bit_width = 1;
+    body.append(&bit_width, 1);
+    body.append(std::move(index_rle));
+    auto body_size = static_cast<int32_t>(body.size_bytes());
+
+    page_header v1_hdr{
+      .uncompressed_page_size = body_size,
+      .compressed_page_size = body_size,
+      .type = data_page_header_v1{
+        .num_values = num_values,
+        .data_encoding = encoding::rle_dictionary,
+        .definition_level_encoding = encoding::rle,
+        .repetition_level_encoding = encoding::rle,
+      },
+    };
+    iobuf data_page = encode(v1_hdr);
+    data_page.append(std::move(body));
+
+    iobuf chunk;
+    chunk.append(std::move(dict_page));
+    chunk.append(std::move(data_page));
+
+    column_meta_data col_meta{
+      .codec = compression_codec::uncompressed,
+      .num_values = num_values,
+      .total_uncompressed_size = static_cast<int64_t>(chunk.size_bytes()),
+      .total_compressed_size = static_cast<int64_t>(chunk.size_bytes()),
+      .data_page_offset = 0,
+    };
+    auto schema = make_schema(
+      "val", field_repetition_type::required, i32_type());
+    index_schema(schema);
+
+    auto result = decode_column_chunk(
+                    std::move(chunk), col_meta, schema.children[0])
+                    .get();
+
+    EXPECT_EQ(result.values.length, num_values);
+    auto* i32d = std::get_if<column_array::i32_data>(&result.values.data);
+    ASSERT_NE(i32d, nullptr);
+    ASSERT_EQ(i32d->values.size(), num_values);
+    EXPECT_EQ(i32d->values[0], 42);
+    EXPECT_EQ(i32d->values[1], 99);
+    EXPECT_EQ(i32d->values[2], 99);
+    EXPECT_EQ(i32d->values[3], 42);
+}
+
+// NOLINTEND(*magic-number*)
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/tests/encoding_test.cc
+++ b/src/v/serde/parquet/tests/encoding_test.cc
@@ -348,6 +348,233 @@ INSTANTIATE_TEST_SUITE_P(
       }
     }));
 
+// --- Decoder Round-Trip Tests ---
+
+TEST(LevelDecoding, RoundTripRLE) {
+    chunked_vector<def_level> levels;
+    for (int i = 0; i < 100; ++i) {
+        levels.push_back(def_level(static_cast<int16_t>(i % 3)));
+    }
+    def_level max_val = def_level(2);
+    auto encoded = encode_levels(max_val, levels);
+    auto byte_length = static_cast<int32_t>(encoded.size_bytes());
+    iobuf_parser parser(std::move(encoded));
+    auto decoded = decode_levels(parser, 100, byte_length, max_val);
+    ASSERT_EQ(decoded.size(), levels.size());
+    for (size_t i = 0; i < levels.size(); ++i) {
+        EXPECT_EQ(decoded[i], levels[i]) << "mismatch at index " << i;
+    }
+}
+
+TEST(LevelDecoding, RoundTripAllSameValue) {
+    chunked_vector<rep_level> levels;
+    for (int i = 0; i < 50; ++i) {
+        levels.push_back(rep_level(3));
+    }
+    rep_level max_val = rep_level(3);
+    auto encoded = encode_levels(max_val, levels);
+    auto byte_length = static_cast<int32_t>(encoded.size_bytes());
+    iobuf_parser parser(std::move(encoded));
+    auto decoded = decode_levels(parser, 50, byte_length, max_val);
+    ASSERT_EQ(decoded.size(), 50);
+    for (const auto& v : decoded) {
+        EXPECT_EQ(v, rep_level(3));
+    }
+}
+
+TEST(LevelDecoding, RoundTripAllZeros) {
+    chunked_vector<def_level> levels;
+    for (int i = 0; i < 20; ++i) {
+        levels.push_back(def_level(0));
+    }
+    def_level max_val = def_level(0);
+    auto encoded = encode_levels(max_val, levels);
+    auto byte_length = static_cast<int32_t>(encoded.size_bytes());
+    iobuf_parser parser(std::move(encoded));
+    auto decoded = decode_levels(parser, 20, byte_length, max_val);
+    ASSERT_EQ(decoded.size(), 20);
+    for (const auto& v : decoded) {
+        EXPECT_EQ(v, def_level(0));
+    }
+}
+
+TEST(LevelDecoding, BitpackedInput) {
+    // Hand-craft a bitpack encoded input:
+    // bit_width=2, 1 group of 8 values: [0, 1, 2, 3, 0, 1, 2, 3]
+    // Header: (1 << 1) | 1 = 3 (1 group, bitpack marker)
+    // Data: 8 values * 2 bits = 16 bits = 2 bytes
+    // Values packed LSB first:
+    //   0=00, 1=01, 2=10, 3=11, 0=00, 1=01, 2=10, 3=11
+    //   byte 0: 11 10 01 00 = 0xE4
+    //   byte 1: 11 10 01 00 = 0xE4
+    iobuf encoded;
+    uint8_t header = 3; // (1 group << 1) | 1
+    encoded.append(&header, 1);
+    uint8_t b0 = 0xE4;
+    uint8_t b1 = 0xE4;
+    encoded.append(&b0, 1);
+    encoded.append(&b1, 1);
+    auto byte_length = static_cast<int32_t>(encoded.size_bytes());
+    iobuf_parser parser(std::move(encoded));
+    auto decoded = decode_levels(parser, 8, byte_length, def_level(3));
+    ASSERT_EQ(decoded.size(), 8);
+    EXPECT_EQ(decoded[0], def_level(0));
+    EXPECT_EQ(decoded[1], def_level(1));
+    EXPECT_EQ(decoded[2], def_level(2));
+    EXPECT_EQ(decoded[3], def_level(3));
+    EXPECT_EQ(decoded[4], def_level(0));
+    EXPECT_EQ(decoded[5], def_level(1));
+    EXPECT_EQ(decoded[6], def_level(2));
+    EXPECT_EQ(decoded[7], def_level(3));
+}
+
+TEST(PlainDecoding, BooleanRoundTrip) {
+    plain_encoder<boolean_value> enc;
+    chunked_vector<boolean_value> values{
+      {true},
+      {false},
+      {true},
+      {true},
+      {false},
+      {false},
+      {true},
+      {false},
+      {true}};
+    for (auto& v : values) {
+        enc.add_value(v);
+    }
+    auto encoded = enc.get_encoded_buf();
+    iobuf_parser parser(std::move(encoded));
+    plain_decoder<boolean_value> dec(parser);
+    for (size_t i = 0; i < values.size(); ++i) {
+        EXPECT_EQ(dec.read_value(), values[i]) << "mismatch at " << i;
+    }
+}
+
+TEST(PlainDecoding, Int32RoundTrip) {
+    plain_encoder<int32_value> enc;
+    chunked_vector<int32_value> values{
+      {0},
+      {42},
+      {-1},
+      {std::numeric_limits<int32_t>::max()},
+      {std::numeric_limits<int32_t>::min()}};
+    for (auto& v : values) {
+        enc.add_value(v);
+    }
+    auto encoded = enc.get_encoded_buf();
+    iobuf_parser parser(std::move(encoded));
+    plain_decoder<int32_value> dec(parser);
+    for (size_t i = 0; i < values.size(); ++i) {
+        EXPECT_EQ(dec.read_value(), values[i]) << "mismatch at " << i;
+    }
+}
+
+TEST(PlainDecoding, Int64RoundTrip) {
+    plain_encoder<int64_value> enc;
+    chunked_vector<int64_value> values{
+      {0},
+      {-999},
+      {std::numeric_limits<int64_t>::max()},
+      {std::numeric_limits<int64_t>::min()}};
+    for (auto& v : values) {
+        enc.add_value(v);
+    }
+    auto encoded = enc.get_encoded_buf();
+    iobuf_parser parser(std::move(encoded));
+    plain_decoder<int64_value> dec(parser);
+    for (size_t i = 0; i < values.size(); ++i) {
+        EXPECT_EQ(dec.read_value(), values[i]) << "mismatch at " << i;
+    }
+}
+
+TEST(PlainDecoding, Float32RoundTrip) {
+    plain_encoder<float32_value> enc;
+    chunked_vector<float32_value> values{
+      {0.0f},
+      {-1.5f},
+      {std::numeric_limits<float>::max()},
+      {std::numeric_limits<float>::min()}};
+    for (auto& v : values) {
+        enc.add_value(v);
+    }
+    auto encoded = enc.get_encoded_buf();
+    iobuf_parser parser(std::move(encoded));
+    plain_decoder<float32_value> dec(parser);
+    for (size_t i = 0; i < values.size(); ++i) {
+        EXPECT_EQ(dec.read_value(), values[i]) << "mismatch at " << i;
+    }
+}
+
+TEST(PlainDecoding, Float64RoundTrip) {
+    plain_encoder<float64_value> enc;
+    chunked_vector<float64_value> values{
+      {0.0}, {3.14159}, {std::numeric_limits<double>::max()}};
+    for (auto& v : values) {
+        enc.add_value(v);
+    }
+    auto encoded = enc.get_encoded_buf();
+    iobuf_parser parser(std::move(encoded));
+    plain_decoder<float64_value> dec(parser);
+    for (size_t i = 0; i < values.size(); ++i) {
+        EXPECT_EQ(dec.read_value(), values[i]) << "mismatch at " << i;
+    }
+}
+
+TEST(PlainDecoding, ByteArrayRoundTrip) {
+    plain_encoder<byte_array_value> enc;
+    enc.add_value(byte_array_value{iobuf::from("hello")});
+    enc.add_value(byte_array_value{iobuf::from("")});
+    enc.add_value(byte_array_value{iobuf::from("world")});
+    auto encoded = enc.get_encoded_buf();
+    iobuf_parser parser(std::move(encoded));
+    plain_decoder<byte_array_value> dec(parser);
+    EXPECT_EQ(dec.read_value().val, iobuf::from("hello"));
+    EXPECT_EQ(dec.read_value().val, iobuf::from(""));
+    EXPECT_EQ(dec.read_value().val, iobuf::from("world"));
+}
+
+TEST(PlainDecoding, FixedByteArrayRoundTrip) {
+    plain_encoder<fixed_byte_array_value> enc;
+    enc.add_value(fixed_byte_array_value{iobuf::from("\x01\x02\x03\x04")});
+    enc.add_value(fixed_byte_array_value{iobuf::from("\x05\x06\x07\x08")});
+    auto encoded = enc.get_encoded_buf();
+    iobuf_parser parser(std::move(encoded));
+    plain_decoder<fixed_byte_array_value> dec(parser, 4);
+    EXPECT_EQ(dec.read_value().val, iobuf::from("\x01\x02\x03\x04"));
+    EXPECT_EQ(dec.read_value().val, iobuf::from("\x05\x06\x07\x08"));
+}
+
+TEST(RleBpInt32, RoundTripViaLevels) {
+    chunked_vector<def_level> levels;
+    for (int i = 0; i < 20; ++i) {
+        levels.push_back(def_level(static_cast<int16_t>(i % 4)));
+    }
+    auto encoded = encode_levels(def_level(3), levels);
+    auto byte_length = static_cast<int32_t>(encoded.size_bytes());
+    iobuf_parser parser(std::move(encoded));
+    auto decoded = decode_rle_bp_int32(parser, 20, byte_length, 2);
+    ASSERT_EQ(decoded.size(), 20);
+    for (int i = 0; i < 20; ++i) {
+        EXPECT_EQ(decoded[i], i % 4) << "index " << i;
+    }
+}
+
+TEST(RleBpInt32, AllZeros) {
+    chunked_vector<def_level> levels;
+    for (int i = 0; i < 10; ++i) {
+        levels.push_back(def_level(0));
+    }
+    auto encoded = encode_levels(def_level(0), levels);
+    auto byte_length = static_cast<int32_t>(encoded.size_bytes());
+    iobuf_parser parser(std::move(encoded));
+    auto decoded = decode_rle_bp_int32(parser, 10, byte_length, 0);
+    ASSERT_EQ(decoded.size(), 10);
+    for (const auto& v : decoded) {
+        EXPECT_EQ(v, 0);
+    }
+}
+
 // NOLINTEND(*magic-number*)
 
 } // namespace serde::parquet

--- a/src/v/serde/parquet/tests/flattened_schema_test.cc
+++ b/src/v/serde/parquet/tests/flattened_schema_test.cc
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "serde/parquet/flattened_schema.h"
+#include "serde/parquet/schema.h"
+
+#include <gtest/gtest.h>
+
+using namespace serde::parquet;
+
+namespace {
+
+template<typename... Args>
+schema_element
+group_node(ss::sstring name, field_repetition_type rep_type, Args... args) {
+    chunked_vector<schema_element> children;
+    (children.push_back(std::move(args)), ...);
+    return {
+      .type = std::monostate{},
+      .repetition_type = rep_type,
+      .path = {std::move(name)},
+      .children = std::move(children),
+    };
+}
+
+schema_element leaf_node(
+  ss::sstring name,
+  field_repetition_type rep_type,
+  physical_type ptype,
+  logical_type ltype = logical_type{}) {
+    return {
+      .type = ptype,
+      .repetition_type = rep_type,
+      .path = {std::move(name)},
+      .logical_type = ltype,
+    };
+}
+
+schema_element leaf_node_with_field_id(
+  ss::sstring name,
+  field_repetition_type rep_type,
+  physical_type ptype,
+  int32_t fid) {
+    return {
+      .type = ptype,
+      .repetition_type = rep_type,
+      .path = {std::move(name)},
+      .field_id = fid,
+    };
+}
+
+// Compare two schemas, ignoring fields that flatten() doesn't preserve
+// (position, full path, max_definition_level, max_repetition_level).
+void expect_schema_equal(
+  const schema_element& actual, const schema_element& expected) {
+    EXPECT_EQ(actual.type, expected.type);
+    EXPECT_EQ(actual.repetition_type, expected.repetition_type);
+    ASSERT_EQ(actual.path.size(), 1)
+      << "unflatten should produce single-segment paths";
+    EXPECT_EQ(actual.name(), expected.name());
+    EXPECT_EQ(actual.field_id, expected.field_id);
+    EXPECT_EQ(actual.logical_type, expected.logical_type);
+    ASSERT_EQ(actual.children.size(), expected.children.size());
+    for (size_t i = 0; i < actual.children.size(); ++i) {
+        expect_schema_equal(actual.children[i], expected.children[i]);
+    }
+}
+
+} // namespace
+
+TEST(FlattenedSchema, RoundTripFlat) {
+    using field_repetition_type::optional;
+    using field_repetition_type::required;
+    auto schema = group_node(
+      "schema",
+      required,
+      leaf_node("a", required, i32_type()),
+      leaf_node("b", optional, i64_type()),
+      leaf_node("c", required, f64_type()));
+    auto flat = flatten(schema);
+    auto result = unflatten(flat);
+    expect_schema_equal(result, schema);
+}
+
+TEST(FlattenedSchema, RoundTripNested) {
+    using field_repetition_type::optional;
+    using field_repetition_type::required;
+    auto schema = group_node(
+      "schema",
+      required,
+      group_node(
+        "inner",
+        optional,
+        leaf_node("x", required, i32_type()),
+        leaf_node("y", required, i32_type())),
+      leaf_node("z", required, f64_type()));
+    auto flat = flatten(schema);
+    auto result = unflatten(flat);
+    expect_schema_equal(result, schema);
+}
+
+TEST(FlattenedSchema, RoundTripDeeplyNested) {
+    using field_repetition_type::optional;
+    using field_repetition_type::repeated;
+    using field_repetition_type::required;
+    auto schema = group_node(
+      "schema",
+      required,
+      group_node(
+        "persons",
+        optional,
+        group_node(
+          "persons_tuple",
+          repeated,
+          group_node(
+            "name",
+            required,
+            leaf_node("first", optional, byte_array_type(), string_type()),
+            leaf_node("last", required, byte_array_type(), string_type())),
+          leaf_node("id", optional, i32_type()),
+          group_node(
+            "phones",
+            repeated,
+            group_node(
+              "phones_tuple",
+              repeated,
+              leaf_node(
+                "number", optional, byte_array_type(), string_type()))))));
+    auto flat = flatten(schema);
+    auto result = unflatten(flat);
+    expect_schema_equal(result, schema);
+}
+
+TEST(FlattenedSchema, RoundTripWithFieldIds) {
+    using field_repetition_type::required;
+    auto schema = group_node(
+      "schema",
+      required,
+      leaf_node_with_field_id("a", required, i32_type(), 1),
+      leaf_node_with_field_id("b", required, i64_type(), 2));
+    auto flat = flatten(schema);
+    auto result = unflatten(flat);
+    expect_schema_equal(result, schema);
+}
+
+TEST(FlattenedSchema, RoundTripWithLogicalTypes) {
+    using field_repetition_type::optional;
+    using field_repetition_type::required;
+    auto schema = group_node(
+      "schema",
+      required,
+      leaf_node("s", optional, byte_array_type(), string_type()),
+      leaf_node(
+        "ts", required, i64_type(), timestamp_type{true, time_unit::micros}),
+      leaf_node("d", required, i32_type(), date_type()),
+      leaf_node(
+        "dec",
+        optional,
+        byte_array_type(),
+        decimal_type{.scale = 2, .precision = 10}));
+    auto flat = flatten(schema);
+    auto result = unflatten(flat);
+    expect_schema_equal(result, schema);
+}
+
+TEST(FlattenedSchema, RoundTripSingleLeaf) {
+    using field_repetition_type::required;
+    auto schema = group_node(
+      "schema", required, leaf_node("only", required, bool_type()));
+    auto flat = flatten(schema);
+    auto result = unflatten(flat);
+    expect_schema_equal(result, schema);
+}
+
+TEST(FlattenedSchema, EmptyInput) {
+    chunked_vector<flattened_schema> empty;
+    auto result = unflatten(empty);
+    EXPECT_TRUE(result.children.empty());
+    EXPECT_TRUE(result.path.empty());
+}

--- a/src/v/serde/parquet/tests/metadata_roundtrip_test.cc
+++ b/src/v/serde/parquet/tests/metadata_roundtrip_test.cc
@@ -1,0 +1,345 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "serde/parquet/flattened_schema.h"
+#include "serde/parquet/metadata.h"
+#include "serde/parquet/schema.h"
+
+#include <gtest/gtest.h>
+
+using namespace serde::parquet;
+
+namespace {
+
+template<typename... Args>
+chunked_vector<Args...> list(auto&&... items) {
+    chunked_vector<Args...> v;
+    (v.push_back(std::forward<decltype(items)>(items)), ...);
+    return v;
+}
+
+} // namespace
+
+TEST(MetadataRoundTrip, PageHeaderDataV2) {
+    page_header original{
+      .uncompressed_page_size = 4096,
+      .compressed_page_size = 2048,
+      .crc = crc::crc32(0xDEAD),
+      .type = data_page_header{
+        .num_values = 100,
+        .num_nulls = 5,
+        .num_rows = 95,
+        .data_encoding = encoding::plain,
+        .definition_levels_byte_length = 12,
+        .repetition_levels_byte_length = 8,
+        .is_compressed = true,
+        .stats = statistics{
+          .null_count = 5,
+          .max = std::make_optional<statistics::bound>(
+            iobuf::from("\xFF\xFE"), true),
+          .min = std::make_optional<statistics::bound>(
+            iobuf::from("\x00\x01"), false),
+        },
+      },
+    };
+    auto encoded = encode(original);
+    iobuf_parser parser(std::move(encoded));
+    auto decoded = decode(parser, page_header_tag{});
+
+    EXPECT_EQ(decoded.uncompressed_page_size, original.uncompressed_page_size);
+    EXPECT_EQ(decoded.compressed_page_size, original.compressed_page_size);
+    EXPECT_EQ(decoded.crc.value(), original.crc.value());
+
+    auto* dph = std::get_if<data_page_header>(&decoded.type);
+    ASSERT_NE(dph, nullptr);
+    auto* oph = std::get_if<data_page_header>(&original.type);
+    EXPECT_EQ(dph->num_values, oph->num_values);
+    EXPECT_EQ(dph->num_nulls, oph->num_nulls);
+    EXPECT_EQ(dph->num_rows, oph->num_rows);
+    EXPECT_EQ(dph->data_encoding, oph->data_encoding);
+    EXPECT_EQ(
+      dph->definition_levels_byte_length, oph->definition_levels_byte_length);
+    EXPECT_EQ(
+      dph->repetition_levels_byte_length, oph->repetition_levels_byte_length);
+    EXPECT_EQ(dph->is_compressed, oph->is_compressed);
+    ASSERT_TRUE(dph->stats.has_value());
+    EXPECT_EQ(dph->stats->null_count, 5);
+    ASSERT_TRUE(dph->stats->max.has_value());
+    EXPECT_EQ(dph->stats->max->value, oph->stats->max->value);
+    EXPECT_EQ(dph->stats->max->is_exact, true);
+    ASSERT_TRUE(dph->stats->min.has_value());
+    EXPECT_EQ(dph->stats->min->value, oph->stats->min->value);
+    EXPECT_EQ(dph->stats->min->is_exact, false);
+    EXPECT_EQ(parser.bytes_left(), 0);
+}
+
+TEST(MetadataRoundTrip, PageHeaderDataV1) {
+    page_header original{
+      .uncompressed_page_size = 4096,
+      .compressed_page_size = 2048,
+      .crc = crc::crc32(0xBEEF),
+      .type = data_page_header_v1{
+        .num_values = 100,
+        .data_encoding = encoding::rle_dictionary,
+        .definition_level_encoding = encoding::rle,
+        .repetition_level_encoding = encoding::rle,
+      },
+    };
+    auto encoded = encode(original);
+    iobuf_parser parser(std::move(encoded));
+    auto decoded = decode(parser, page_header_tag{});
+
+    EXPECT_EQ(decoded.uncompressed_page_size, 4096);
+    EXPECT_EQ(decoded.compressed_page_size, 2048);
+    auto* v1 = std::get_if<data_page_header_v1>(&decoded.type);
+    ASSERT_NE(v1, nullptr);
+    EXPECT_EQ(v1->num_values, 100);
+    EXPECT_EQ(v1->data_encoding, encoding::rle_dictionary);
+    EXPECT_EQ(v1->definition_level_encoding, encoding::rle);
+    EXPECT_EQ(v1->repetition_level_encoding, encoding::rle);
+}
+
+TEST(MetadataRoundTrip, PageHeaderDictionary) {
+    page_header original{
+      .uncompressed_page_size = 99999,
+      .compressed_page_size = 0,
+      .crc = crc::crc32(0xEEEE),
+      .type = dictionary_page_header{
+        .num_values = 44,
+        .data_encoding = encoding::rle,
+        .is_sorted = true,
+      },
+    };
+    auto encoded = encode(original);
+    iobuf_parser parser(std::move(encoded));
+    auto decoded = decode(parser, page_header_tag{});
+
+    EXPECT_EQ(decoded.uncompressed_page_size, 99999);
+    EXPECT_EQ(decoded.crc.value(), 0xEEEE);
+    auto* dp = std::get_if<dictionary_page_header>(&decoded.type);
+    ASSERT_NE(dp, nullptr);
+    EXPECT_EQ(dp->num_values, 44);
+    EXPECT_EQ(dp->data_encoding, encoding::rle);
+    EXPECT_EQ(dp->is_sorted, true);
+    EXPECT_EQ(parser.bytes_left(), 0);
+}
+
+TEST(MetadataRoundTrip, FileMetadataFull) {
+    file_metadata original{
+      .version = 2,
+      .schema = flatten(schema_element{
+        .path = {"root"},
+        .children = list<schema_element>(
+          schema_element{
+            .type = i32_type{},
+            .repetition_type = field_repetition_type::optional,
+            .path = {"foo"},
+            .field_id = 1,
+            .logical_type = time_type{
+              .is_adjusted_to_utc = true,
+              .unit = time_unit::millis,
+            },
+          },
+          schema_element{
+            .type = byte_array_type{.fixed_length = 16},
+            .repetition_type = field_repetition_type::required,
+            .path = {"bar"},
+            .field_id = 2,
+            .logical_type = uuid_type{},
+          },
+          schema_element{
+            .type = bool_type{},
+            .repetition_type = field_repetition_type::repeated,
+            .path = {"baz"},
+            .field_id = 3,
+          }),
+      }),
+      .num_rows = 999,
+      .row_groups = list<row_group>(row_group{
+        .columns = list<column_chunk>(column_chunk{
+          .meta_data = {
+            .type = bool_type{},
+            .encodings = {encoding::plain, encoding::rle},
+            .path_in_schema = {"foo", "baz"},
+            .codec = compression_codec::zstd,
+            .num_values = 888,
+            .total_uncompressed_size = 9999,
+            .total_compressed_size = 9,
+            .key_value_metadata = {{"qux", "thid"}},
+            .data_page_offset = 2,
+            .index_page_offset = 5,
+            .dictionary_page_offset = 9,
+            .stats = statistics{
+              .null_count = 9,
+              .max = std::make_optional<statistics::bound>(
+                iobuf::from("\xFF"), true),
+              .min = std::make_optional<statistics::bound>(
+                iobuf::from(std::string_view{"\x00", 1}), false),
+            },
+          },
+        }),
+        .total_byte_size = 321,
+        .num_rows = 1,
+        .sorting_columns = list<sorting_column>(
+          sorting_column{.column_idx = 0, .descending = true, .nulls_first = false}),
+        .file_offset = 1234,
+        .total_compressed_size = 231,
+        .ordinal = 0,
+      }),
+      .key_value_metadata = {{"key1", "val1"}, {"key2", "val2"}},
+      .created_by = "redpanda test",
+      .column_orders = {column_order::type_defined},
+    };
+
+    auto encoded = encode(original);
+    auto decoded = decode(std::move(encoded), file_metadata_tag{});
+
+    EXPECT_EQ(decoded.version, 2);
+    EXPECT_EQ(decoded.num_rows, 999);
+    EXPECT_EQ(decoded.created_by, "redpanda test");
+
+    // Schema
+    ASSERT_EQ(decoded.schema.size(), original.schema.size());
+    for (size_t i = 0; i < decoded.schema.size(); ++i) {
+        EXPECT_EQ(decoded.schema[i].name, original.schema[i].name);
+        EXPECT_EQ(decoded.schema[i].type, original.schema[i].type);
+        EXPECT_EQ(
+          decoded.schema[i].repetition_type,
+          original.schema[i].repetition_type);
+        EXPECT_EQ(decoded.schema[i].field_id, original.schema[i].field_id);
+        EXPECT_EQ(
+          decoded.schema[i].logical_type, original.schema[i].logical_type);
+        EXPECT_EQ(
+          decoded.schema[i].num_children, original.schema[i].num_children);
+    }
+
+    // Row groups
+    ASSERT_EQ(decoded.row_groups.size(), 1);
+    const auto& rg = decoded.row_groups[0];
+    EXPECT_EQ(rg.total_byte_size, 321);
+    EXPECT_EQ(rg.num_rows, 1);
+    EXPECT_EQ(rg.file_offset, 1234);
+    EXPECT_EQ(rg.total_compressed_size, 231);
+    EXPECT_EQ(rg.ordinal, 0);
+
+    // Sorting columns
+    ASSERT_EQ(rg.sorting_columns.size(), 1);
+    EXPECT_EQ(rg.sorting_columns[0].column_idx, 0);
+    EXPECT_EQ(rg.sorting_columns[0].descending, true);
+    EXPECT_EQ(rg.sorting_columns[0].nulls_first, false);
+
+    // Column chunk
+    ASSERT_EQ(rg.columns.size(), 1);
+    const auto& cc = rg.columns[0];
+    EXPECT_EQ(cc.meta_data.codec, compression_codec::zstd);
+    EXPECT_EQ(cc.meta_data.num_values, 888);
+    EXPECT_EQ(cc.meta_data.data_page_offset, 2);
+    EXPECT_EQ(cc.meta_data.index_page_offset, 5);
+    EXPECT_EQ(cc.meta_data.dictionary_page_offset, 9);
+    ASSERT_EQ(cc.meta_data.encodings.size(), 2);
+    EXPECT_EQ(cc.meta_data.encodings[0], encoding::plain);
+    EXPECT_EQ(cc.meta_data.encodings[1], encoding::rle);
+    ASSERT_EQ(cc.meta_data.path_in_schema.size(), 2);
+    EXPECT_EQ(cc.meta_data.path_in_schema[0], "foo");
+    EXPECT_EQ(cc.meta_data.path_in_schema[1], "baz");
+    ASSERT_EQ(cc.meta_data.key_value_metadata.size(), 1);
+    EXPECT_EQ(cc.meta_data.key_value_metadata[0].first, "qux");
+    EXPECT_EQ(cc.meta_data.key_value_metadata[0].second, "thid");
+
+    // Key-value metadata
+    ASSERT_EQ(decoded.key_value_metadata.size(), 2);
+    EXPECT_EQ(decoded.key_value_metadata[0].first, "key1");
+    EXPECT_EQ(decoded.key_value_metadata[0].second, "val1");
+
+    // Column orders
+    ASSERT_EQ(decoded.column_orders.size(), 1);
+    EXPECT_EQ(decoded.column_orders[0], column_order::type_defined);
+}
+
+TEST(MetadataRoundTrip, FileMetadataMinimal) {
+    file_metadata original{
+      .version = 2,
+      .schema = flatten(
+        schema_element{
+          .path = {"root"},
+          .children = list<schema_element>(schema_element{
+            .type = i64_type{},
+            .repetition_type = field_repetition_type::required,
+            .path = {"col"},
+          }),
+        }),
+      .num_rows = 0,
+      .created_by = "test",
+    };
+
+    auto encoded = encode(original);
+    auto decoded = decode(std::move(encoded), file_metadata_tag{});
+
+    EXPECT_EQ(decoded.version, 2);
+    EXPECT_EQ(decoded.num_rows, 0);
+    EXPECT_EQ(decoded.schema.size(), 2);
+    EXPECT_TRUE(decoded.row_groups.empty());
+}
+
+TEST(MetadataRoundTrip, SchemaWithAllLogicalTypes) {
+    file_metadata original{
+      .version = 2,
+      .schema = flatten(schema_element{
+        .path = {"root"},
+        .children = list<schema_element>(
+          schema_element{
+            .type = byte_array_type{},
+            .repetition_type = field_repetition_type::required,
+            .path = {"str"},
+            .logical_type = string_type{},
+          },
+          schema_element{
+            .type = i32_type{},
+            .repetition_type = field_repetition_type::required,
+            .path = {"date"},
+            .logical_type = date_type{},
+          },
+          schema_element{
+            .type = i64_type{},
+            .repetition_type = field_repetition_type::required,
+            .path = {"ts"},
+            .logical_type = timestamp_type{
+              .is_adjusted_to_utc = false,
+              .unit = time_unit::nanos,
+            },
+          },
+          schema_element{
+            .type = byte_array_type{},
+            .repetition_type = field_repetition_type::required,
+            .path = {"dec"},
+            .logical_type = decimal_type{.scale = 3, .precision = 18},
+          },
+          schema_element{
+            .type = i32_type{},
+            .repetition_type = field_repetition_type::required,
+            .path = {"u16"},
+            .logical_type = int_type{.bit_width = 16, .is_signed = false},
+          }),
+      }),
+      .num_rows = 0,
+      .created_by = "test",
+    };
+
+    auto encoded = encode(original);
+    auto decoded = decode(std::move(encoded), file_metadata_tag{});
+
+    ASSERT_EQ(decoded.schema.size(), original.schema.size());
+    for (size_t i = 0; i < decoded.schema.size(); ++i) {
+        EXPECT_EQ(
+          decoded.schema[i].logical_type, original.schema[i].logical_type)
+          << "mismatch at schema index " << i;
+    }
+}

--- a/src/v/serde/parquet/tests/reader_test.cc
+++ b/src/v/serde/parquet/tests/reader_test.cc
@@ -1,0 +1,296 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "bytes/iostream.h"
+#include "serde/parquet/reader.h"
+#include "serde/parquet/schema.h"
+#include "serde/parquet/value.h"
+#include "serde/parquet/writer.h"
+
+#include <gtest/gtest.h>
+
+namespace serde::parquet {
+
+namespace {
+
+template<typename... Args>
+schema_element
+group_node(ss::sstring name, field_repetition_type rep_type, Args... args) {
+    chunked_vector<schema_element> children;
+    (children.push_back(std::move(args)), ...);
+    return {
+      .type = std::monostate{},
+      .repetition_type = rep_type,
+      .path = {std::move(name)},
+      .children = std::move(children),
+    };
+}
+
+schema_element leaf_node(
+  ss::sstring name,
+  field_repetition_type rep_type,
+  physical_type ptype,
+  logical_type ltype = logical_type{}) {
+    return {
+      .type = ptype,
+      .repetition_type = rep_type,
+      .path = {std::move(name)},
+      .logical_type = ltype,
+    };
+}
+
+template<typename... Args>
+group_value record(Args... field) {
+    chunked_vector<group_member> fields;
+    (fields.push_back(group_member{std::move(field)}), ...);
+    return fields;
+}
+
+iobuf write_to_iobuf(
+  schema_element schema,
+  chunked_vector<group_value> rows,
+  bool compress = false) {
+    iobuf file;
+    writer w(
+      {.schema = std::move(schema), .compress = compress},
+      make_iobuf_ref_output_stream(file));
+    w.init().get();
+    for (auto& row : rows) {
+        w.write_row(std::move(row)).get();
+    }
+    w.close().get();
+    return file;
+}
+
+} // namespace
+
+// NOLINTBEGIN(*magic-number*)
+
+TEST(ParquetReader, FlatRequiredInt32) {
+    using field_repetition_type::required;
+    auto schema = group_node(
+      "root",
+      required,
+      leaf_node("a", required, i32_type()),
+      leaf_node("b", required, i64_type()));
+
+    chunked_vector<group_value> rows;
+    rows.push_back(record(int32_value{1}, int64_value{10}));
+    rows.push_back(record(int32_value{2}, int64_value{20}));
+    rows.push_back(record(int32_value{3}, int64_value{30}));
+
+    auto file = write_to_iobuf(std::move(schema), std::move(rows));
+    auto records = read_file_as_records(std::move(file)).get();
+
+    ASSERT_EQ(records.size(), 3);
+    EXPECT_EQ(records[0], record(int32_value{1}, int64_value{10}));
+    EXPECT_EQ(records[1], record(int32_value{2}, int64_value{20}));
+    EXPECT_EQ(records[2], record(int32_value{3}, int64_value{30}));
+}
+
+TEST(ParquetReader, OptionalWithNulls) {
+    using field_repetition_type::optional;
+    using field_repetition_type::required;
+    auto schema = group_node(
+      "root",
+      required,
+      leaf_node("a", optional, i32_type()),
+      leaf_node("b", optional, i64_type()));
+
+    chunked_vector<group_value> rows;
+    rows.push_back(record(int32_value{42}, null_value{}));
+    rows.push_back(record(null_value{}, int64_value{99}));
+    rows.push_back(record(int32_value{7}, int64_value{88}));
+
+    auto file = write_to_iobuf(std::move(schema), std::move(rows));
+    auto records = read_file_as_records(std::move(file)).get();
+
+    ASSERT_EQ(records.size(), 3);
+    EXPECT_EQ(records[0], record(int32_value{42}, null_value{}));
+    EXPECT_EQ(records[1], record(null_value{}, int64_value{99}));
+    EXPECT_EQ(records[2], record(int32_value{7}, int64_value{88}));
+}
+
+TEST(ParquetReader, CompressedZstd) {
+    using field_repetition_type::required;
+    auto schema = group_node(
+      "root", required, leaf_node("val", required, i32_type()));
+
+    chunked_vector<group_value> rows;
+    for (int i = 0; i < 50; ++i) {
+        rows.push_back(record(int32_value{i}));
+    }
+
+    auto file = write_to_iobuf(
+      std::move(schema), std::move(rows), /*compress=*/true);
+    auto records = read_file_as_records(std::move(file)).get();
+
+    ASSERT_EQ(records.size(), 50);
+    for (int i = 0; i < 50; ++i) {
+        EXPECT_EQ(records[i], record(int32_value{i}));
+    }
+}
+
+TEST(ParquetReader, StringColumn) {
+    using field_repetition_type::required;
+    auto schema = group_node(
+      "root",
+      required,
+      leaf_node("name", required, byte_array_type{}, string_type()));
+
+    chunked_vector<group_value> rows;
+    rows.push_back(record(byte_array_value{iobuf::from("alice")}));
+    rows.push_back(record(byte_array_value{iobuf::from("bob")}));
+    rows.push_back(record(byte_array_value{iobuf::from("charlie")}));
+
+    auto file = write_to_iobuf(std::move(schema), std::move(rows));
+    auto records = read_file_as_records(std::move(file)).get();
+
+    ASSERT_EQ(records.size(), 3);
+    EXPECT_EQ(records[0], record(byte_array_value{iobuf::from("alice")}));
+    EXPECT_EQ(records[1], record(byte_array_value{iobuf::from("bob")}));
+    EXPECT_EQ(records[2], record(byte_array_value{iobuf::from("charlie")}));
+}
+
+TEST(ParquetReader, NestedOptionalStruct) {
+    using field_repetition_type::optional;
+    using field_repetition_type::required;
+    auto schema = group_node(
+      "root",
+      required,
+      group_node(
+        "inner",
+        optional,
+        leaf_node("x", required, i32_type()),
+        leaf_node("y", required, i32_type())),
+      leaf_node("z", required, i64_type()));
+
+    chunked_vector<group_value> rows;
+    rows.push_back(
+      record(value(record(int32_value{1}, int32_value{2})), int64_value{100}));
+    rows.push_back(record(null_value{}, int64_value{200}));
+
+    auto file = write_to_iobuf(std::move(schema), std::move(rows));
+    auto records = read_file_as_records(std::move(file)).get();
+
+    ASSERT_EQ(records.size(), 2);
+    EXPECT_EQ(
+      records[0],
+      record(value(record(int32_value{1}, int32_value{2})), int64_value{100}));
+    EXPECT_EQ(records[1], record(null_value{}, int64_value{200}));
+}
+
+TEST(ParquetReader, ColumnarAccess) {
+    using field_repetition_type::required;
+    auto schema = group_node(
+      "root",
+      required,
+      leaf_node("a", required, i32_type()),
+      leaf_node("b", required, i64_type()));
+
+    chunked_vector<group_value> rows;
+    for (int i = 0; i < 10; ++i) {
+        rows.push_back(record(int32_value{i}, int64_value{i * 100}));
+    }
+
+    auto file = write_to_iobuf(std::move(schema), std::move(rows));
+    auto result = read_file(std::move(file)).get();
+
+    EXPECT_EQ(result.metadata.version, 2);
+    EXPECT_EQ(result.metadata.num_rows, 10);
+    ASSERT_EQ(result.row_groups.size(), 1);
+    auto& batch = result.row_groups[0];
+    EXPECT_EQ(batch.num_rows, 10);
+    ASSERT_EQ(batch.columns.size(), 2);
+
+    auto* col_a = std::get_if<column_array::i32_data>(&batch.columns[0].data);
+    ASSERT_NE(col_a, nullptr);
+    ASSERT_EQ(col_a->values.size(), 10);
+    EXPECT_EQ(col_a->values[0], 0);
+    EXPECT_EQ(col_a->values[9], 9);
+
+    auto* col_b = std::get_if<column_array::i64_data>(&batch.columns[1].data);
+    ASSERT_NE(col_b, nullptr);
+    ASSERT_EQ(col_b->values.size(), 10);
+    EXPECT_EQ(col_b->values[0], 0);
+    EXPECT_EQ(col_b->values[9], 900);
+}
+
+TEST(ParquetReader, ColumnProjection) {
+    using field_repetition_type::required;
+    auto schema = group_node(
+      "root",
+      required,
+      leaf_node("a", required, i32_type()),
+      leaf_node("b", required, i64_type()),
+      leaf_node("c", required, f64_type()));
+
+    chunked_vector<group_value> rows;
+    for (int i = 0; i < 5; ++i) {
+        rows.push_back(
+          record(int32_value{i}, int64_value{i * 10}, float64_value{i * 1.5}));
+    }
+
+    auto file = write_to_iobuf(std::move(schema), std::move(rows));
+
+    // Project only column "b"
+    reader_options opts;
+    chunked_vector<ss::sstring> proj_path;
+    proj_path.push_back("b");
+    opts.column_projection.push_back(std::move(proj_path));
+
+    auto result = read_file(std::move(file), std::move(opts)).get();
+
+    ASSERT_EQ(result.row_groups.size(), 1);
+    auto& batch = result.row_groups[0];
+    // Only one column should be decoded
+    ASSERT_EQ(batch.columns.size(), 1);
+    auto* col_b = std::get_if<column_array::i64_data>(&batch.columns[0].data);
+    ASSERT_NE(col_b, nullptr);
+    ASSERT_EQ(col_b->values.size(), 5);
+    for (int i = 0; i < 5; ++i) {
+        EXPECT_EQ(col_b->values[i], i * 10);
+    }
+}
+
+TEST(ParquetReader, ReadAsRecordsWithProjection) {
+    using field_repetition_type::required;
+    auto schema = group_node(
+      "root",
+      required,
+      leaf_node("a", required, i32_type()),
+      leaf_node("b", required, i64_type()));
+
+    chunked_vector<group_value> rows;
+    rows.push_back(record(int32_value{1}, int64_value{10}));
+    rows.push_back(record(int32_value{2}, int64_value{20}));
+
+    auto file = write_to_iobuf(std::move(schema), std::move(rows));
+
+    // Project only column "a" — should produce records with only "a"
+    // (previously this crashed because the projected batch didn't match
+    // the full schema)
+    reader_options opts;
+    chunked_vector<ss::sstring> proj_path;
+    proj_path.push_back("a");
+    opts.column_projection.push_back(std::move(proj_path));
+
+    auto records = read_file_as_records(std::move(file), std::move(opts)).get();
+
+    ASSERT_EQ(records.size(), 2);
+    // Records should have only the projected column
+    EXPECT_EQ(records[0], record(int32_value{1}));
+    EXPECT_EQ(records[1], record(int32_value{2}));
+}
+
+// NOLINTEND(*magic-number*)
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/tests/writer_test.cc
+++ b/src/v/serde/parquet/tests/writer_test.cc
@@ -52,6 +52,27 @@ group_value make_row(size_t data_size) {
 
 } // namespace
 
+schema_element two_column_schema() {
+    chunked_vector<schema_element> children;
+    children.push_back(
+      leaf_node("str_col", field_repetition_type::required, byte_array_type{}));
+    children.push_back(
+      leaf_node("int_col", field_repetition_type::required, i32_type{}));
+    return {
+      .repetition_type = field_repetition_type::required,
+      .path = {"root"},
+      .children = std::move(children),
+    };
+}
+
+group_value make_two_col_row(ss::sstring str_val, int32_t int_val) {
+    chunked_vector<group_member> fields;
+    fields.push_back(
+      group_member{byte_array_value{iobuf::from(std::move(str_val))}});
+    fields.push_back(group_member{int32_value{int_val}});
+    return fields;
+}
+
 // NOLINTBEGIN(*magic-number*)
 
 TEST(ParquetWriter, FlushesRowGroupWhenSizeExceeded) {
@@ -102,6 +123,113 @@ TEST(ParquetWriter, NoEarlyFlushWhenUnderLimit) {
     EXPECT_GE(stats.buffered_size, row_size * rows_to_write);
 
     w.close().get();
+}
+
+TEST(ParquetWriter, StatsTruncation) {
+    constexpr int32_t max_stats_len = 16;
+
+    iobuf file;
+    writer w(
+      {
+        .schema = two_column_schema(),
+        .max_stats_truncate_length = max_stats_len,
+      },
+      make_iobuf_ref_output_stream(file));
+    w.init().get();
+
+    // Write rows with long strings (50 bytes) that should be truncated.
+    // Use distinct min/max values to exercise both truncation paths.
+    std::string long_min(50, 'A');
+    std::string long_max(50, 'Z');
+    w.write_row(make_two_col_row(ss::sstring(long_min), 1)).get();
+    w.write_row(make_two_col_row(ss::sstring(long_max), 100)).get();
+
+    auto metadata = w.close().get();
+
+    ASSERT_EQ(metadata.row_groups.size(), 1);
+    auto& rg = metadata.row_groups[0];
+    ASSERT_GE(rg.columns.size(), 2);
+
+    // Column 0: byte_array (string) -- should be truncated
+    auto& str_stats = rg.columns[0].meta_data.stats;
+    ASSERT_TRUE(str_stats.has_value());
+    ASSERT_TRUE(str_stats->min.has_value());
+    ASSERT_TRUE(str_stats->max.has_value());
+    EXPECT_LE(
+      static_cast<int32_t>(str_stats->min->value.size_bytes()), max_stats_len);
+    EXPECT_FALSE(str_stats->min->is_exact);
+    EXPECT_LE(
+      static_cast<int32_t>(str_stats->max->value.size_bytes()), max_stats_len);
+    EXPECT_FALSE(str_stats->max->is_exact);
+
+    // Column 1: int32 -- should NOT be truncated (always small)
+    auto& int_stats = rg.columns[1].meta_data.stats;
+    ASSERT_TRUE(int_stats.has_value());
+    ASSERT_TRUE(int_stats->min.has_value());
+    ASSERT_TRUE(int_stats->max.has_value());
+    EXPECT_TRUE(int_stats->min->is_exact);
+    EXPECT_TRUE(int_stats->max->is_exact);
+}
+
+TEST(ParquetWriter, StatsNotTruncatedWhenShort) {
+    constexpr int32_t max_stats_len = 16;
+
+    iobuf file;
+    writer w(
+      {
+        .schema = simple_schema(),
+        .max_stats_truncate_length = max_stats_len,
+      },
+      make_iobuf_ref_output_stream(file));
+    w.init().get();
+
+    // Write short strings (10 bytes) -- should not be truncated
+    w.write_row(make_row(10)).get();
+
+    auto metadata = w.close().get();
+
+    ASSERT_EQ(metadata.row_groups.size(), 1);
+    auto& stats = metadata.row_groups[0].columns[0].meta_data.stats;
+    ASSERT_TRUE(stats.has_value());
+    ASSERT_TRUE(stats->min.has_value());
+    ASSERT_TRUE(stats->max.has_value());
+    EXPECT_EQ(static_cast<int32_t>(stats->min->value.size_bytes()), 10);
+    EXPECT_TRUE(stats->min->is_exact);
+    EXPECT_EQ(static_cast<int32_t>(stats->max->value.size_bytes()), 10);
+    EXPECT_TRUE(stats->max->is_exact);
+}
+
+TEST(ParquetWriter, StatsTruncateMaxAllFF) {
+    constexpr int32_t max_stats_len = 4;
+
+    iobuf file;
+    writer w(
+      {
+        .schema = simple_schema(),
+        .max_stats_truncate_length = max_stats_len,
+      },
+      make_iobuf_ref_output_stream(file));
+    w.init().get();
+
+    // Create a string where the first max_stats_len bytes are all 0xFF,
+    // which cannot be incremented for max truncation.
+    std::string all_ff(10, '\xFF');
+    chunked_vector<group_member> fields;
+    fields.push_back(
+      group_member{byte_array_value{iobuf::from(std::move(all_ff))}});
+    w.write_row(group_value{std::move(fields)}).get();
+
+    auto metadata = w.close().get();
+
+    ASSERT_EQ(metadata.row_groups.size(), 1);
+    auto& stats = metadata.row_groups[0].columns[0].meta_data.stats;
+    ASSERT_TRUE(stats.has_value());
+    ASSERT_TRUE(stats->max.has_value());
+    // When all prefix bytes are 0xFF, truncation keeps the full prefix
+    // and marks it as exact since it can't form a tighter upper bound.
+    EXPECT_EQ(
+      static_cast<int32_t>(stats->max->value.size_bytes()), max_stats_len);
+    EXPECT_TRUE(stats->max->is_exact);
 }
 
 // NOLINTEND(*magic-number*)

--- a/src/v/serde/parquet/writer.cc
+++ b/src/v/serde/parquet/writer.cc
@@ -58,6 +58,8 @@ public:
                   element,
                   {
                     .compress = _opts.compress,
+                    .max_stats_truncate_length
+                    = _opts.max_stats_truncate_length,
                   }),
               });
         });
@@ -157,7 +159,7 @@ public:
         _row_groups.push_back(std::move(rg));
     }
 
-    ss::future<> close() {
+    ss::future<file_metadata> close() {
         co_await flush_row_group();
         int64_t num_rows = 0;
         for (const auto& rg : _row_groups) {
@@ -169,22 +171,23 @@ public:
                 orders.push_back(column_order::type_defined);
             }
         });
-        auto encoded_footer = encode(
-          file_metadata{
-            .version = 2,
-            .schema = flatten(_opts.schema),
-            .num_rows = num_rows,
-            .row_groups = std::move(_row_groups),
-            .key_value_metadata = std::move(_opts.metadata),
-            .created_by = fmt::format(
-              "Redpanda version {} (build {})", _opts.version, _opts.build),
-            .column_orders = std::move(orders),
-          });
+        file_metadata metadata{
+          .version = 2,
+          .schema = flatten(_opts.schema),
+          .num_rows = num_rows,
+          .row_groups = std::move(_row_groups),
+          .key_value_metadata = std::move(_opts.metadata),
+          .created_by = fmt::format(
+            "Redpanda version {} (build {})", _opts.version, _opts.build),
+          .column_orders = std::move(orders),
+        };
+        auto encoded_footer = encode(metadata);
         size_t footer_size = encoded_footer.size_bytes();
         co_await write_iobuf(std::move(encoded_footer));
         co_await write_iobuf(encode_footer_size(footer_size));
         co_await write_iobuf(iobuf::from("PAR1"));
         co_await _output.close();
+        co_return std::move(metadata);
     }
 
 private:
@@ -236,6 +239,6 @@ file_stats writer::stats() const { return _impl->stats(); }
 
 ss::future<> writer::flush_row_group() { return _impl->flush_row_group(); }
 
-ss::future<> writer::close() { return _impl->close(); }
+ss::future<file_metadata> writer::close() { return _impl->close(); }
 
 } // namespace serde::parquet

--- a/src/v/serde/parquet/writer.h
+++ b/src/v/serde/parquet/writer.h
@@ -13,6 +13,7 @@
 
 #include "base/units.h"
 #include "container/chunked_vector.h"
+#include "serde/parquet/metadata.h"
 #include "serde/parquet/schema.h"
 #include "serde/parquet/value.h"
 
@@ -56,6 +57,11 @@ public:
         // Row groups are flushed to disk internally if they exceed this size.
         static constexpr int64_t default_row_group_size = 128_MiB;
         int64_t row_group_size = default_row_group_size;
+
+        // Max byte length for byte array column statistics. Values exceeding
+        // this are truncated with is_exact=false. Default matches Arrow/Spark.
+        static constexpr int32_t default_max_stats_length = 16;
+        int32_t max_stats_truncate_length = default_max_stats_length;
     };
 
     // Create a new parquet file writer using the given options that
@@ -107,7 +113,7 @@ public:
     // class.
     //
     // The resulting future must be awaited before destroying this object.
-    ss::future<> close();
+    ss::future<file_metadata> close();
 
 private:
     class impl;

--- a/src/v/serde/thrift/BUILD
+++ b/src/v/serde/thrift/BUILD
@@ -19,6 +19,7 @@ redpanda_cc_library(
         "//src/v/base",
         "//src/v/bytes",
         "//src/v/bytes:iobuf",
+        "//src/v/bytes:iobuf_parser",
         "//src/v/utils:named_type",
         "//src/v/utils:vint",
         "@seastar",

--- a/src/v/serde/thrift/compact.cc
+++ b/src/v/serde/thrift/compact.cc
@@ -128,4 +128,138 @@ void list_encoder::write_long_form_field_header(
     write_uvint<int32_t>(_buf, static_cast<int32_t>(field_id));
 }
 
+struct_decoder::struct_decoder(iobuf_parser_base& parser)
+  : _parser(parser) {}
+
+std::optional<struct_decoder::field_header>
+struct_decoder::read_field_header() {
+    auto byte = _parser.consume_type<uint8_t>();
+    if (byte == 0) {
+        return std::nullopt;
+    }
+    auto type = static_cast<field_type>(byte & 0x0FU);
+    auto delta = static_cast<uint8_t>(byte >> 4U);
+    field_id id;
+    if (delta != 0) {
+        id = field_id(_last_field_id() + delta);
+    } else {
+        id = field_id(decode_i16(_parser));
+    }
+    _last_field_id = id;
+    // Booleans are encoded in the type byte itself — no additional value bytes.
+    // The caller should check the type for boolean_true/boolean_false rather
+    // than reading a separate value.
+    return field_header{id, type};
+}
+
+void struct_decoder::skip_field(field_type type) {
+    switch (type) {
+    case field_type::boolean_true:
+    case field_type::boolean_false:
+        break;
+    case field_type::i8:
+        _parser.skip(1);
+        break;
+    case field_type::i16:
+        decode_i16(_parser);
+        break;
+    case field_type::i32:
+        decode_i32(_parser);
+        break;
+    case field_type::i64:
+        decode_i64(_parser);
+        break;
+    case field_type::f64:
+        _parser.skip(8);
+        break;
+    case field_type::binary:
+        decode_binary(_parser);
+        break;
+    case field_type::uuid:
+        _parser.skip(16);
+        break;
+    case field_type::list:
+    case field_type::set: {
+        list_decoder list(_parser);
+        for (size_t i = 0; i < list.size(); ++i) {
+            skip_field(list.element_type());
+        }
+        break;
+    }
+    case field_type::map: {
+        auto [count, _] = _parser.read_unsigned_varint();
+        if (count == 0) {
+            break;
+        }
+        auto kv_byte = _parser.consume_type<uint8_t>();
+        auto key_type = static_cast<field_type>(kv_byte >> 4U);
+        auto val_type = static_cast<field_type>(kv_byte & 0x0FU);
+        for (size_t i = 0; i < count; ++i) {
+            skip_field(key_type);
+            skip_field(val_type);
+        }
+        break;
+    }
+    case field_type::structure: {
+        struct_decoder nested(_parser);
+        while (auto hdr = nested.read_field_header()) {
+            nested.skip_field(hdr->type);
+        }
+        break;
+    }
+    }
+}
+
+list_decoder::list_decoder(iobuf_parser_base& parser) {
+    auto byte = parser.consume_type<uint8_t>();
+    _type = static_cast<field_type>(byte & 0x0FU);
+    auto size_nibble = static_cast<uint8_t>(byte >> 4U);
+    constexpr uint8_t long_form_marker = 0x0FU;
+    if (size_nibble == long_form_marker) {
+        auto [val, _] = parser.read_unsigned_varint();
+        _size = val;
+    } else {
+        _size = size_nibble;
+    }
+}
+
+field_type list_decoder::element_type() const { return _type; }
+
+size_t list_decoder::size() const { return _size; }
+
+int16_t decode_i16(iobuf_parser_base& parser) {
+    auto [val, _] = parser.read_varlong();
+    if (
+      val < std::numeric_limits<int16_t>::min()
+      || val > std::numeric_limits<int16_t>::max()) {
+        throw std::out_of_range("thrift i16 value out of range");
+    }
+    return static_cast<int16_t>(val);
+}
+
+int32_t decode_i32(iobuf_parser_base& parser) {
+    auto [val, _] = parser.read_varlong();
+    if (
+      val < std::numeric_limits<int32_t>::min()
+      || val > std::numeric_limits<int32_t>::max()) {
+        throw std::out_of_range("thrift i32 value out of range");
+    }
+    return static_cast<int32_t>(val);
+}
+
+int64_t decode_i64(iobuf_parser_base& parser) {
+    auto [val, _] = parser.read_varlong();
+    return val;
+}
+
+ss::sstring decode_string(iobuf_parser_base& parser) {
+    auto [len, _] = parser.read_unsigned_varint();
+    return parser.read_string_unsafe(len);
+}
+
+iobuf decode_binary(iobuf_parser_base& parser) {
+    auto [len, _] = parser.read_unsigned_varint();
+    return parser.copy(len);
+}
+
 } // namespace serde::thrift

--- a/src/v/serde/thrift/compact.h
+++ b/src/v/serde/thrift/compact.h
@@ -13,9 +13,11 @@
 
 #include "bytes/bytes.h"
 #include "bytes/iobuf.h"
+#include "bytes/iobuf_parser.h"
 #include "utils/named_type.h"
 
 #include <cstdint>
+#include <optional>
 
 namespace serde::thrift {
 
@@ -127,5 +129,71 @@ bytes encode_string(std::string_view str);
  * First an unsigned varint for the length, then the binary contents itself.
  */
 iobuf encode_binary(iobuf b);
+
+// A Struct decoder reads fields from Thrift compact encoded data. Fields are
+// decoded one at a time; the caller reads each field's value based on its type.
+// Unknown fields can be skipped for forward compatibility.
+//
+// Usage:
+//   struct_decoder dec(parser);
+//   while (auto hdr = dec.read_field_header()) {
+//       switch (hdr->id()) {
+//       case 1: my_field = decode_i32(parser); break;
+//       default: dec.skip_field(parser, hdr->type); break;
+//       }
+//   }
+class struct_decoder {
+public:
+    struct field_header {
+        field_id id;
+        field_type type;
+    };
+
+    explicit struct_decoder(iobuf_parser_base& parser);
+
+    // Read the next field header. Returns std::nullopt at the stop field.
+    //
+    // Booleans: the value is encoded in the type nibble itself
+    // (boolean_true / boolean_false). No separate value read is needed.
+    std::optional<field_header> read_field_header();
+
+    // Skip a field value of the given type. Used for unknown fields.
+    void skip_field(field_type type);
+
+private:
+    iobuf_parser_base& _parser;
+    field_id _last_field_id = field_id(0);
+};
+
+// A List/Set decoder reads the header and provides element count and type.
+// The caller reads each element's value based on the element type.
+//
+// Usage:
+//   list_decoder dec(parser);
+//   for (size_t i = 0; i < dec.size(); ++i) {
+//       values.push_back(decode_i32(parser));
+//   }
+class list_decoder {
+public:
+    explicit list_decoder(iobuf_parser_base& parser);
+
+    field_type element_type() const;
+    size_t size() const;
+
+private:
+    field_type _type;
+    size_t _size;
+};
+
+// Decode a zigzag-encoded varint as int16_t.
+int16_t decode_i16(iobuf_parser_base& parser);
+// Decode a zigzag-encoded varint as int32_t.
+int32_t decode_i32(iobuf_parser_base& parser);
+// Decode a zigzag-encoded varint as int64_t.
+int64_t decode_i64(iobuf_parser_base& parser);
+// Decode a length-prefixed UTF-8 string.
+ss::sstring decode_string(iobuf_parser_base& parser);
+// Decode a length-prefixed binary blob.
+iobuf decode_binary(iobuf_parser_base& parser);
 
 } // namespace serde::thrift

--- a/src/v/serde/thrift/tests/BUILD
+++ b/src/v/serde/thrift/tests/BUILD
@@ -11,6 +11,7 @@ redpanda_cc_gtest(
     deps = [
         "//src/v/base",
         "//src/v/bytes:iobuf",
+        "//src/v/bytes:iobuf_parser",
         "//src/v/serde/thrift:compact",
         "//src/v/test_utils:gtest",
         "//src/v/utils:vint",

--- a/src/v/serde/thrift/tests/compact_test.cc
+++ b/src/v/serde/thrift/tests/compact_test.cc
@@ -140,4 +140,426 @@ TEST(StringEncoding, Large) {
       buf_from(unsigned_vint::to_bytes(large_count)));
 }
 
+TEST(StructDecoding, Empty) {
+    iobuf data = struct_encoder().write_stop();
+    iobuf_parser parser(std::move(data));
+    struct_decoder dec(parser);
+    EXPECT_EQ(dec.read_field_header(), std::nullopt);
+}
+
+TEST(StructDecoding, SingleI32Field) {
+    struct_encoder enc;
+    enc.write_field(field_id(1), field_type::i32, vint::to_bytes(42));
+    iobuf data = std::move(enc).write_stop();
+    iobuf_parser parser(std::move(data));
+    struct_decoder dec(parser);
+    auto hdr = dec.read_field_header();
+    ASSERT_TRUE(hdr.has_value());
+    EXPECT_EQ(hdr->id, field_id(1));
+    EXPECT_EQ(hdr->type, field_type::i32);
+    EXPECT_EQ(decode_i32(parser), 42);
+    EXPECT_EQ(dec.read_field_header(), std::nullopt);
+}
+
+TEST(StructDecoding, MultipleFields) {
+    struct_encoder enc;
+    enc.write_field(field_id(1), field_type::i32, vint::to_bytes(100));
+    enc.write_field(field_id(2), field_type::i64, vint::to_bytes(int64_t{200}));
+    enc.write_field(field_id(3), field_type::binary, encode_string("hello"));
+    iobuf data = std::move(enc).write_stop();
+    iobuf_parser parser(std::move(data));
+    struct_decoder dec(parser);
+
+    auto hdr1 = dec.read_field_header();
+    ASSERT_TRUE(hdr1.has_value());
+    EXPECT_EQ(hdr1->id, field_id(1));
+    EXPECT_EQ(decode_i32(parser), 100);
+
+    auto hdr2 = dec.read_field_header();
+    ASSERT_TRUE(hdr2.has_value());
+    EXPECT_EQ(hdr2->id, field_id(2));
+    EXPECT_EQ(decode_i64(parser), 200);
+
+    auto hdr3 = dec.read_field_header();
+    ASSERT_TRUE(hdr3.has_value());
+    EXPECT_EQ(hdr3->id, field_id(3));
+    EXPECT_EQ(decode_string(parser), "hello");
+
+    EXPECT_EQ(dec.read_field_header(), std::nullopt);
+}
+
+TEST(StructDecoding, LargeFieldId) {
+    struct_encoder enc;
+    enc.write_field(field_id(25), field_type::i32, vint::to_bytes(7));
+    iobuf data = std::move(enc).write_stop();
+    iobuf_parser parser(std::move(data));
+    struct_decoder dec(parser);
+    auto hdr = dec.read_field_header();
+    ASSERT_TRUE(hdr.has_value());
+    EXPECT_EQ(hdr->id, field_id(25));
+    EXPECT_EQ(decode_i32(parser), 7);
+    EXPECT_EQ(dec.read_field_header(), std::nullopt);
+}
+
+TEST(StructDecoding, NegativeFieldDelta) {
+    struct_encoder enc;
+    enc.write_field(field_id(25), field_type::i32, vint::to_bytes(1));
+    enc.write_field(field_id(1), field_type::i32, vint::to_bytes(2));
+    iobuf data = std::move(enc).write_stop();
+    iobuf_parser parser(std::move(data));
+    struct_decoder dec(parser);
+
+    auto hdr1 = dec.read_field_header();
+    ASSERT_TRUE(hdr1.has_value());
+    EXPECT_EQ(hdr1->id, field_id(25));
+    EXPECT_EQ(decode_i32(parser), 1);
+
+    auto hdr2 = dec.read_field_header();
+    ASSERT_TRUE(hdr2.has_value());
+    EXPECT_EQ(hdr2->id, field_id(1));
+    EXPECT_EQ(decode_i32(parser), 2);
+
+    EXPECT_EQ(dec.read_field_header(), std::nullopt);
+}
+
+TEST(StructDecoding, BooleanFields) {
+    struct_encoder enc;
+    enc.write_field(field_id(1), field_type::boolean_true, bytes{});
+    enc.write_field(field_id(2), field_type::boolean_false, bytes{});
+    iobuf data = std::move(enc).write_stop();
+    iobuf_parser parser(std::move(data));
+    struct_decoder dec(parser);
+
+    auto hdr1 = dec.read_field_header();
+    ASSERT_TRUE(hdr1.has_value());
+    EXPECT_EQ(hdr1->id, field_id(1));
+    EXPECT_EQ(hdr1->type, field_type::boolean_true);
+
+    auto hdr2 = dec.read_field_header();
+    ASSERT_TRUE(hdr2.has_value());
+    EXPECT_EQ(hdr2->id, field_id(2));
+    EXPECT_EQ(hdr2->type, field_type::boolean_false);
+
+    EXPECT_EQ(dec.read_field_header(), std::nullopt);
+}
+
+TEST(StructDecoding, SkipUnknownFields) {
+    struct_encoder enc;
+    enc.write_field(field_id(1), field_type::i32, vint::to_bytes(42));
+    enc.write_field(field_id(2), field_type::i64, vint::to_bytes(int64_t{99}));
+    enc.write_field(field_id(3), field_type::i32, vint::to_bytes(7));
+    iobuf data = std::move(enc).write_stop();
+    iobuf_parser parser(std::move(data));
+    struct_decoder dec(parser);
+
+    // Read field 1
+    auto hdr1 = dec.read_field_header();
+    EXPECT_EQ(hdr1->id, field_id(1));
+    EXPECT_EQ(decode_i32(parser), 42);
+
+    // Skip field 2 (unknown)
+    auto hdr2 = dec.read_field_header();
+    EXPECT_EQ(hdr2->id, field_id(2));
+    dec.skip_field(hdr2->type);
+
+    // Read field 3
+    auto hdr3 = dec.read_field_header();
+    EXPECT_EQ(hdr3->id, field_id(3));
+    EXPECT_EQ(decode_i32(parser), 7);
+
+    EXPECT_EQ(dec.read_field_header(), std::nullopt);
+}
+
+TEST(StructDecoding, NestedStruct) {
+    // Inner struct: field 1 = i32(99)
+    struct_encoder inner;
+    inner.write_field(field_id(1), field_type::i32, vint::to_bytes(99));
+    auto inner_data = std::move(inner).write_stop();
+
+    // Outer struct: field 1 = i32(42), field 2 = inner struct
+    struct_encoder outer;
+    outer.write_field(field_id(1), field_type::i32, vint::to_bytes(42));
+    outer.write_field(
+      field_id(2), field_type::structure, std::move(inner_data));
+    iobuf data = std::move(outer).write_stop();
+
+    iobuf_parser parser(std::move(data));
+    struct_decoder dec(parser);
+
+    auto hdr1 = dec.read_field_header();
+    EXPECT_EQ(hdr1->id, field_id(1));
+    EXPECT_EQ(decode_i32(parser), 42);
+
+    auto hdr2 = dec.read_field_header();
+    EXPECT_EQ(hdr2->id, field_id(2));
+    EXPECT_EQ(hdr2->type, field_type::structure);
+
+    // Decode nested struct
+    struct_decoder nested(parser);
+    auto nhdr = nested.read_field_header();
+    ASSERT_TRUE(nhdr.has_value());
+    EXPECT_EQ(nhdr->id, field_id(1));
+    EXPECT_EQ(decode_i32(parser), 99);
+    EXPECT_EQ(nested.read_field_header(), std::nullopt);
+
+    EXPECT_EQ(dec.read_field_header(), std::nullopt);
+}
+
+TEST(StructDecoding, SkipNestedStruct) {
+    struct_encoder inner;
+    inner.write_field(field_id(1), field_type::i32, vint::to_bytes(99));
+    inner.write_field(field_id(2), field_type::binary, encode_string("nested"));
+    auto inner_data = std::move(inner).write_stop();
+
+    struct_encoder outer;
+    outer.write_field(
+      field_id(1), field_type::structure, std::move(inner_data));
+    outer.write_field(field_id(2), field_type::i32, vint::to_bytes(7));
+    iobuf data = std::move(outer).write_stop();
+
+    iobuf_parser parser(std::move(data));
+    struct_decoder dec(parser);
+
+    // Skip nested struct
+    auto hdr1 = dec.read_field_header();
+    EXPECT_EQ(hdr1->type, field_type::structure);
+    dec.skip_field(hdr1->type);
+
+    // Read the field after the nested struct
+    auto hdr2 = dec.read_field_header();
+    EXPECT_EQ(hdr2->id, field_id(2));
+    EXPECT_EQ(decode_i32(parser), 7);
+
+    EXPECT_EQ(dec.read_field_header(), std::nullopt);
+}
+
+TEST(ListDecoding, DecodeEmpty) {
+    auto data = list_encoder(0, field_type::i32).finish();
+    iobuf_parser parser(std::move(data));
+    list_decoder dec(parser);
+    EXPECT_EQ(dec.element_type(), field_type::i32);
+    EXPECT_EQ(dec.size(), 0);
+}
+
+TEST(ListDecoding, DecodeSingle) {
+    list_encoder enc(1, field_type::i32);
+    enc.write_element(vint::to_bytes(42));
+    auto data = std::move(enc).finish();
+    iobuf_parser parser(std::move(data));
+    list_decoder dec(parser);
+    EXPECT_EQ(dec.element_type(), field_type::i32);
+    EXPECT_EQ(dec.size(), 1);
+    EXPECT_EQ(decode_i32(parser), 42);
+}
+
+TEST(ListDecoding, DecodeLarge) {
+    constexpr size_t count = 10'000;
+    list_encoder enc(count, field_type::i32);
+    for (size_t i = 0; i < count; ++i) {
+        enc.write_element(vint::to_bytes(static_cast<int32_t>(i)));
+    }
+    auto data = std::move(enc).finish();
+    iobuf_parser parser(std::move(data));
+    list_decoder dec(parser);
+    EXPECT_EQ(dec.element_type(), field_type::i32);
+    EXPECT_EQ(dec.size(), count);
+    for (size_t i = 0; i < count; ++i) {
+        EXPECT_EQ(decode_i32(parser), static_cast<int32_t>(i));
+    }
+}
+
+TEST(ListDecoding, ListOfStrings) {
+    list_encoder enc(3, field_type::binary);
+    enc.write_element(bytes_to_iobuf(encode_string("alpha")));
+    enc.write_element(bytes_to_iobuf(encode_string("beta")));
+    enc.write_element(bytes_to_iobuf(encode_string("gamma")));
+    auto data = std::move(enc).finish();
+    iobuf_parser parser(std::move(data));
+    list_decoder dec(parser);
+    EXPECT_EQ(dec.size(), 3);
+    EXPECT_EQ(decode_string(parser), "alpha");
+    EXPECT_EQ(decode_string(parser), "beta");
+    EXPECT_EQ(decode_string(parser), "gamma");
+}
+
+TEST(ListDecoding, SkipList) {
+    // Struct: field 1 = list of i32, field 2 = i32(7)
+    list_encoder list_enc(3, field_type::i32);
+    list_enc.write_element(vint::to_bytes(1));
+    list_enc.write_element(vint::to_bytes(2));
+    list_enc.write_element(vint::to_bytes(3));
+
+    struct_encoder enc;
+    enc.write_field(
+      field_id(1), field_type::list, std::move(list_enc).finish());
+    enc.write_field(field_id(2), field_type::i32, vint::to_bytes(7));
+    iobuf data = std::move(enc).write_stop();
+
+    iobuf_parser parser(std::move(data));
+    struct_decoder dec(parser);
+
+    auto hdr1 = dec.read_field_header();
+    EXPECT_EQ(hdr1->type, field_type::list);
+    dec.skip_field(hdr1->type);
+
+    auto hdr2 = dec.read_field_header();
+    EXPECT_EQ(hdr2->id, field_id(2));
+    EXPECT_EQ(decode_i32(parser), 7);
+}
+
+TEST(StringDecoding, RoundTrip) {
+    auto encoded = bytes_to_iobuf(encode_string("hello world"));
+    iobuf_parser parser(std::move(encoded));
+    EXPECT_EQ(decode_string(parser), "hello world");
+    EXPECT_EQ(parser.bytes_left(), 0);
+}
+
+TEST(StringDecoding, Empty) {
+    auto encoded = bytes_to_iobuf(encode_string(""));
+    iobuf_parser parser(std::move(encoded));
+    EXPECT_EQ(decode_string(parser), "");
+    EXPECT_EQ(parser.bytes_left(), 0);
+}
+
+TEST(BinaryDecoding, RoundTrip) {
+    iobuf original;
+    original.append("binary\x00data", 11);
+    auto encoded = encode_binary(original.copy());
+    iobuf_parser parser(std::move(encoded));
+    auto decoded = decode_binary(parser);
+    EXPECT_EQ(decoded, original);
+    EXPECT_EQ(parser.bytes_left(), 0);
+}
+
+TEST(IntDecoding, NegativeValues) {
+    auto data = buf_from(vint::to_bytes(int64_t{-1}));
+    iobuf_parser parser(std::move(data));
+    EXPECT_EQ(decode_i32(parser), -1);
+}
+
+TEST(IntDecoding, I64LargeValues) {
+    auto data = buf_from(
+      vint::to_bytes(int64_t{std::numeric_limits<int64_t>::max()}));
+    iobuf_parser parser(std::move(data));
+    EXPECT_EQ(decode_i64(parser), std::numeric_limits<int64_t>::max());
+}
+
+TEST(IntDecoding, I64MinValue) {
+    auto data = buf_from(
+      vint::to_bytes(int64_t{std::numeric_limits<int64_t>::min()}));
+    iobuf_parser parser(std::move(data));
+    EXPECT_EQ(decode_i64(parser), std::numeric_limits<int64_t>::min());
+}
+
+TEST(IntDecoding, I16RoundTrip) {
+    auto data = buf_from(
+      vint::to_bytes(int64_t{std::numeric_limits<int16_t>::max()}));
+    iobuf_parser parser(std::move(data));
+    EXPECT_EQ(decode_i16(parser), std::numeric_limits<int16_t>::max());
+}
+
+TEST(IntDecoding, I16MinValue) {
+    auto data = buf_from(
+      vint::to_bytes(int64_t{std::numeric_limits<int16_t>::min()}));
+    iobuf_parser parser(std::move(data));
+    EXPECT_EQ(decode_i16(parser), std::numeric_limits<int16_t>::min());
+}
+
+TEST(IntDecoding, I16Overflow) {
+    auto data = buf_from(
+      vint::to_bytes(int64_t{std::numeric_limits<int16_t>::max() + 1}));
+    iobuf_parser parser(std::move(data));
+    EXPECT_THROW(decode_i16(parser), std::out_of_range);
+}
+
+TEST(IntDecoding, I32Overflow) {
+    auto data = buf_from(
+      vint::to_bytes(
+        int64_t{int64_t{std::numeric_limits<int32_t>::max()} + 1}));
+    iobuf_parser parser(std::move(data));
+    EXPECT_THROW(decode_i32(parser), std::out_of_range);
+}
+
+TEST(StructDecoding, SkipMap) {
+    // Hand-craft a map: 2 entries, key=i32, val=binary
+    iobuf map_data;
+    auto count_bytes = unsigned_vint::to_bytes(2);
+    map_data.append(count_bytes.data(), count_bytes.size());
+    // kv_type byte: key=i32(5) in high nibble, val=binary(8) in low nibble
+    uint8_t kv_type = (0x05 << 4) | 0x08;
+    map_data.append(&kv_type, 1);
+    // entry 1
+    auto k1 = vint::to_bytes(1);
+    map_data.append(k1.data(), k1.size());
+    map_data.append(bytes_to_iobuf(encode_string("ab")));
+    // entry 2
+    auto k2 = vint::to_bytes(2);
+    map_data.append(k2.data(), k2.size());
+    map_data.append(bytes_to_iobuf(encode_string("cd")));
+
+    struct_encoder enc;
+    enc.write_field(field_id(1), field_type::map, std::move(map_data));
+    enc.write_field(field_id(2), field_type::i32, vint::to_bytes(42));
+    iobuf data = std::move(enc).write_stop();
+
+    iobuf_parser parser(std::move(data));
+    struct_decoder dec(parser);
+    auto hdr1 = dec.read_field_header();
+    EXPECT_EQ(hdr1->type, field_type::map);
+    dec.skip_field(hdr1->type);
+
+    auto hdr2 = dec.read_field_header();
+    EXPECT_EQ(hdr2->id, field_id(2));
+    EXPECT_EQ(decode_i32(parser), 42);
+}
+
+TEST(StructDecoding, SkipEmptyMap) {
+    // Empty map: count=0, no kv_type byte
+    iobuf map_data;
+    auto count_bytes = unsigned_vint::to_bytes(0);
+    map_data.append(count_bytes.data(), count_bytes.size());
+
+    struct_encoder enc;
+    enc.write_field(field_id(1), field_type::map, std::move(map_data));
+    enc.write_field(field_id(2), field_type::i32, vint::to_bytes(7));
+    iobuf data = std::move(enc).write_stop();
+
+    iobuf_parser parser(std::move(data));
+    struct_decoder dec(parser);
+    auto hdr1 = dec.read_field_header();
+    dec.skip_field(hdr1->type);
+
+    auto hdr2 = dec.read_field_header();
+    EXPECT_EQ(hdr2->id, field_id(2));
+    EXPECT_EQ(decode_i32(parser), 7);
+}
+
+TEST(ListDecoding, ShortFormBoundary) {
+    // Size 14 is the max short form value
+    list_encoder enc14(14, field_type::i32);
+    for (int i = 0; i < 14; ++i) {
+        enc14.write_element(vint::to_bytes(i));
+    }
+    auto data14 = std::move(enc14).finish();
+    iobuf_parser parser14(std::move(data14));
+    list_decoder dec14(parser14);
+    EXPECT_EQ(dec14.size(), 14);
+    for (int i = 0; i < 14; ++i) {
+        EXPECT_EQ(decode_i32(parser14), i);
+    }
+
+    // Size 15 triggers long form
+    list_encoder enc15(15, field_type::i32);
+    for (int i = 0; i < 15; ++i) {
+        enc15.write_element(vint::to_bytes(i));
+    }
+    auto data15 = std::move(enc15).finish();
+    iobuf_parser parser15(std::move(data15));
+    list_decoder dec15(parser15);
+    EXPECT_EQ(dec15.size(), 15);
+    for (int i = 0; i < 15; ++i) {
+        EXPECT_EQ(decode_i32(parser15), i);
+    }
+}
+
 } // namespace serde::thrift


### PR DESCRIPTION
## Summary
- Thrift compact protocol decoder for parquet metadata parsing
- Full parquet reader with column projection, dictionary/RLE decoding, Data Page V1/V2
- Record assembler (inverse Dremel) for nested type reconstruction
- Writer improvements: file_metadata exposure, stats truncation

Stack: 1/6