### PR TITLE
datalake: cdc_key_value mode with position delete conversion

### DIFF
--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -358,6 +358,9 @@ metrics_reporter::build_metrics_snapshot() {
         case model::iceberg_mode::variant::debezium:
             ++snapshot.topics_with_iceberg_debezium;
             break;
+        case model::iceberg_mode::variant::cdc_key_value:
+            ++snapshot.topics_with_iceberg_kv;
+            break;
         }
     }
 

--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -151,6 +151,7 @@ redpanda_cc_library(
     deps = [
         ":backlog_controller",
         ":catalog_schema_manager",
+        ":cdc_key_value_translator",
         ":cloud_data_io",
         ":debezium_translator",
         ":location",
@@ -330,6 +331,7 @@ redpanda_cc_library(
         ":table_id_provider",
         "//src/v/base",
         "//src/v/features",
+        "//src/v/iceberg:compatibility_utils",
         "//src/v/iceberg/conversion:conversion_outcome",
         "//src/v/model:batch_compression",
         "//src/v/utils:lazy_abort_source",
@@ -415,6 +417,29 @@ redpanda_cc_library(
         ":schema_identifier",
         "//src/v/base",
         "//src/v/iceberg:datatypes",
+        "//src/v/model",
+    ],
+)
+
+redpanda_cc_library(
+    name = "cdc_key_value_translator",
+    srcs = [
+        "cdc_key_value_translator.cc",
+    ],
+    hdrs = [
+        "cdc_key_value_translator.h",
+    ],
+    implementation_deps = [
+        ":logger",
+        ":table_definition",
+    ],
+    visibility = [":__subpackages__"],
+    deps = [
+        ":record_translator",
+        "//src/v/base",
+        "//src/v/iceberg:datatypes",
+        "//src/v/iceberg:values",
+        "//src/v/metrics",
         "//src/v/model",
     ],
 )

--- a/src/v/datalake/BUILD
+++ b/src/v/datalake/BUILD
@@ -242,11 +242,16 @@ redpanda_cc_library(
         "table_definition.cc",
     ],
     hdrs = [
+        "schema_descriptor.h",
         "table_definition.h",
     ],
     visibility = [":__subpackages__"],
     deps = [
+        "//src/v/iceberg:datatypes",
         "//src/v/iceberg:schema",
+        "//src/v/iceberg:values",
+        "//src/v/model",
+        "@seastar",
     ],
 )
 

--- a/src/v/datalake/cdc_key_value_translator.cc
+++ b/src/v/datalake/cdc_key_value_translator.cc
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "datalake/cdc_key_value_translator.h"
+
+#include "datalake/logger.h"
+#include "datalake/table_definition.h"
+
+namespace datalake {
+
+record_type
+cdc_key_value_translator::build_type(std::optional<shared_resolved_type_t>) {
+    // Identical schema to key_value_translator. The key column lives
+    // inside the redpanda system struct as redpanda.key.
+    auto ret_type = schemaless_struct_type();
+    ret_type.fields.emplace_back(
+      iceberg::nested_field::create(
+        schemaless_next_field_id,
+        "value",
+        iceberg::field_required::no,
+        iceberg::binary_type{}));
+    return record_type{
+      .comps = record_schema_components{
+        .key_identifier = std::nullopt,
+        .val_identifier = std::nullopt,
+      },
+      .type = std::move(ret_type),
+      // The delete key is redpanda.key. The dotted name triggers
+      // nested field lookup via find_field_by_name.
+      .key_field_names = chunked_vector<ss::sstring>{"redpanda.key"},
+    };
+}
+
+ss::future<checked<translated_record, record_translator::errc>>
+cdc_key_value_translator::translate_data(
+  model::partition_id pid,
+  kafka::offset o,
+  std::optional<iobuf> key,
+  const std::optional<shared_resolved_type_t>& val_type,
+  std::optional<iobuf> parsable_val,
+  model::timestamp ts,
+  model::timestamp_type ts_t,
+  const chunked_vector<model::record_header>& headers) {
+    if (val_type.has_value()) {
+        vlog(
+          datalake_log.error,
+          "Must not have parsed schema when using cdc_key_value mode");
+        co_return errc::unexpected_schema;
+    }
+
+    // Build the delete key from the record key.
+    std::optional<iceberg::struct_value> delete_key;
+    if (key.has_value()) {
+        iceberg::struct_value dk;
+        dk.fields.emplace_back(iceberg::binary_value(key->copy()));
+        delete_key = std::move(dk);
+    }
+
+    // Tombstone: null value means pure delete.
+    if (!parsable_val.has_value()) {
+        co_return translated_record{
+          .data_row = std::nullopt,
+          .delete_key = std::move(delete_key),
+        };
+    }
+
+    // Data row identical to key_value_translator.
+    auto system_data = build_rp_struct(
+      pid, o, std::move(key), ts, ts_t, headers);
+    iceberg::struct_value ret_data;
+    ret_data.fields.emplace_back(std::move(system_data));
+    ret_data.fields.emplace_back(
+      iceberg::binary_value(std::move(*parsable_val)));
+
+    co_return translated_record{
+      .data_row = std::move(ret_data),
+      .delete_key = std::move(delete_key),
+    };
+}
+
+} // namespace datalake

--- a/src/v/datalake/cdc_key_value_translator.h
+++ b/src/v/datalake/cdc_key_value_translator.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "datalake/record_translator.h"
+
+namespace datalake {
+
+/// Translates records using key_value semantics with CDC: every record
+/// produces an equality delete for its key, and tombstones (null value)
+/// are treated as pure deletes.
+class cdc_key_value_translator : public record_translator {
+public:
+    record_type
+    build_type(std::optional<shared_resolved_type_t> val_type) override;
+
+    ss::future<checked<translated_record, errc>> translate_data(
+      model::partition_id pid,
+      kafka::offset o,
+      std::optional<iobuf> key,
+      const std::optional<shared_resolved_type_t>& val_type,
+      std::optional<iobuf> parsable_val,
+      model::timestamp ts,
+      model::timestamp_type ts_t,
+      const chunked_vector<model::record_header>& headers) override;
+
+    ~cdc_key_value_translator() override = default;
+};
+
+} // namespace datalake

--- a/src/v/datalake/coordinator/BUILD
+++ b/src/v/datalake/coordinator/BUILD
@@ -210,8 +210,10 @@ redpanda_cc_library(
         "//src/v/iceberg:transaction",
         "//src/v/iceberg:values",
         "//src/v/iceberg:values_bytes",
+        "//src/v/serde/parquet:reader",
         "//src/v/ssx:future_util",
         "//src/v/storage",
+        "//src/v/utils:uuid",
     ],
     deps = [
         ":file_committer",

--- a/src/v/datalake/coordinator/iceberg_file_committer.cc
+++ b/src/v/datalake/coordinator/iceberg_file_committer.cc
@@ -26,10 +26,8 @@
 #include "iceberg/transaction.h"
 #include "iceberg/values.h"
 #include "iceberg/values_bytes.h"
-#include "serde/parquet/reader.h"
 #include "ssx/future-util.h"
 #include "storage/api.h"
-#include "utils/uuid.h"
 
 #include <exception>
 #include <optional>
@@ -518,82 +516,12 @@ private:
             }
         }
 
-        if (
-          !deletes.empty()
-          && strategy == iceberg::delete_commit_strategy::position_deletes) {
-            // Convert equality deletes to position deletes by reading
-            // the key values from the equality delete files, scanning
-            // existing data files for matching rows, and producing
-            // position delete files.
-            iceberg::read_file_fn read_file =
-              [&io](const iceberg::uri& path) -> ss::future<iobuf> {
-                auto res = co_await io.download_object_bytes(path);
-                if (res.has_error()) {
-                    throw std::runtime_error(
-                      fmt::format(
-                        "Failed to download file {}: {}",
-                        path,
-                        static_cast<int>(res.error())));
-                }
-                co_return std::move(res.value());
-            };
-
-            // Read key values from the equality delete files.
-            chunked_vector<serde::parquet::group_value> keys;
-            for (const auto& d : deletes) {
-                auto file_data = co_await read_file(d.file.file_path);
-                auto records = co_await serde::parquet::read_file_as_records(
-                  std::move(file_data));
-                for (auto& r : records) {
-                    keys.push_back(std::move(r));
-                }
-            }
-
-            // Build exclude set: don't scan files we're about to
-            // commit.
-            chunked_hash_set<ss::sstring> exclude;
-            for (const auto& f : all_data) {
-                exclude.insert(f.file.file_path());
-            }
-            for (const auto& d : deletes) {
-                exclude.insert(d.file.file_path());
-            }
-
-            auto positions = co_await iceberg::find_matching_positions(
-              txn.table(), io, keys, *key_field_ids_, exclude, read_file);
-
-            auto pending = co_await iceberg::make_position_deletes(
-              txn.table(), std::move(positions));
-
-            // Upload position delete files and assign URIs.
-            auto table_path_res = io.from_uri(txn.table().location);
-            if (table_path_res.has_error()) {
-                vlog(
-                  datalake_log.warn,
-                  "Failed to parse table location URI: {}",
-                  txn.table().location);
-                co_return file_committer::errc::failed;
-            }
-
-            deletes.clear();
-            for (auto& pd : pending) {
-                auto path = table_path_res.value() / "data"
-                            / fmt::format(
-                              "{}-posdelete.parquet", uuid_t::create());
-                auto file_uri = io.to_uri(path);
-                pd.file.file.file_path = file_uri;
-                auto upload_res = co_await io.upload_object_bytes(
-                  file_uri, std::move(pd.data));
-                if (upload_res.has_error()) {
-                    vlog(
-                      datalake_log.warn,
-                      "Failed to upload position delete file: {}",
-                      file_uri);
-                    co_return file_committer::errc::failed;
-                }
-                deletes.push_back(std::move(pd.file));
-            }
-        }
+        // TODO: when non-debezium translators support upserts without
+        // producing their own delete files (e.g. if upserting by
+        // record key), the coordinator will need to generate deletes
+        // here. That path would call extract_keys() on the upsert
+        // data files, then make_equality_deletes() or
+        // make_position_deletes(), and upload the generated files.
 
         co_return merge_delta_result{
           .data_files = std::move(all_data),

--- a/src/v/datalake/coordinator/iceberg_file_committer.cc
+++ b/src/v/datalake/coordinator/iceberg_file_committer.cc
@@ -26,8 +26,10 @@
 #include "iceberg/transaction.h"
 #include "iceberg/values.h"
 #include "iceberg/values_bytes.h"
+#include "serde/parquet/reader.h"
 #include "ssx/future-util.h"
 #include "storage/api.h"
+#include "utils/uuid.h"
 
 #include <exception>
 #include <optional>
@@ -516,12 +518,82 @@ private:
             }
         }
 
-        // TODO: when non-debezium translators support upserts without
-        // producing their own delete files (e.g. if upserting by
-        // record key), the coordinator will need to generate deletes
-        // here. That path would call extract_keys() on the upsert
-        // data files, then make_equality_deletes() or
-        // make_position_deletes(), and upload the generated files.
+        if (
+          !deletes.empty()
+          && strategy == iceberg::delete_commit_strategy::position_deletes) {
+            // Convert equality deletes to position deletes by reading
+            // the key values from the equality delete files, scanning
+            // existing data files for matching rows, and producing
+            // position delete files.
+            iceberg::read_file_fn read_file =
+              [&io](const iceberg::uri& path) -> ss::future<iobuf> {
+                auto res = co_await io.download_object_bytes(path);
+                if (res.has_error()) {
+                    throw std::runtime_error(
+                      fmt::format(
+                        "Failed to download file {}: {}",
+                        path,
+                        static_cast<int>(res.error())));
+                }
+                co_return std::move(res.value());
+            };
+
+            // Read key values from the equality delete files.
+            chunked_vector<serde::parquet::group_value> keys;
+            for (const auto& d : deletes) {
+                auto file_data = co_await read_file(d.file.file_path);
+                auto records = co_await serde::parquet::read_file_as_records(
+                  std::move(file_data));
+                for (auto& r : records) {
+                    keys.push_back(std::move(r));
+                }
+            }
+
+            // Build exclude set: don't scan files we're about to
+            // commit.
+            chunked_hash_set<ss::sstring> exclude;
+            for (const auto& f : all_data) {
+                exclude.insert(f.file.file_path());
+            }
+            for (const auto& d : deletes) {
+                exclude.insert(d.file.file_path());
+            }
+
+            auto positions = co_await iceberg::find_matching_positions(
+              txn.table(), io, keys, *key_field_ids_, exclude, read_file);
+
+            auto pending = co_await iceberg::make_position_deletes(
+              txn.table(), std::move(positions));
+
+            // Upload position delete files and assign URIs.
+            auto table_path_res = io.from_uri(txn.table().location);
+            if (table_path_res.has_error()) {
+                vlog(
+                  datalake_log.warn,
+                  "Failed to parse table location URI: {}",
+                  txn.table().location);
+                co_return file_committer::errc::failed;
+            }
+
+            deletes.clear();
+            for (auto& pd : pending) {
+                auto path = table_path_res.value() / "data"
+                            / fmt::format(
+                              "{}-posdelete.parquet", uuid_t::create());
+                auto file_uri = io.to_uri(path);
+                pd.file.file.file_path = file_uri;
+                auto upload_res = co_await io.upload_object_bytes(
+                  file_uri, std::move(pd.data));
+                if (upload_res.has_error()) {
+                    vlog(
+                      datalake_log.warn,
+                      "Failed to upload position delete file: {}",
+                      file_uri);
+                    co_return file_committer::errc::failed;
+                }
+                deletes.push_back(std::move(pd.file));
+            }
+        }
 
         co_return merge_delta_result{
           .data_files = std::move(all_data),

--- a/src/v/datalake/datalake_manager.cc
+++ b/src/v/datalake/datalake_manager.cc
@@ -17,6 +17,7 @@
 #include "config/node_config.h"
 #include "datalake/backlog_controller.h"
 #include "datalake/catalog_schema_manager.h"
+#include "datalake/cdc_key_value_translator.h"
 #include "datalake/cloud_data_io.h"
 #include "datalake/coordinator/catalog_factory.h"
 #include "datalake/coordinator/frontend.h"
@@ -51,6 +52,7 @@ static std::unique_ptr<type_resolver> make_type_resolver(
           false,
           "Cannot make record translator when iceberg is disabled, logic bug.");
     case model::iceberg_mode::variant::key_value:
+    case model::iceberg_mode::variant::cdc_key_value:
         return std::make_unique<binary_type_resolver>();
     case model::iceberg_mode::variant::value_schema_id_prefix:
     case model::iceberg_mode::variant::debezium:
@@ -80,6 +82,8 @@ static std::unique_ptr<record_translator> make_record_translator(
           "Cannot make record translator when iceberg is disabled, logic bug.");
     case model::iceberg_mode::variant::key_value:
         return std::make_unique<key_value_translator>();
+    case model::iceberg_mode::variant::cdc_key_value:
+        return std::make_unique<cdc_key_value_translator>();
     case model::iceberg_mode::variant::value_schema_id_prefix:
     case model::iceberg_mode::variant::value_schema_latest:
         return std::make_unique<structured_data_translator>();

--- a/src/v/datalake/debezium_translator.cc
+++ b/src/v/datalake/debezium_translator.cc
@@ -69,52 +69,6 @@ std::optional<size_t> get_redpanda_idx(const iceberg::struct_type& val_type) {
     return std::nullopt;
 }
 
-std::unique_ptr<iceberg::struct_value> build_rp_struct(
-  model::partition_id pid,
-  kafka::offset o,
-  std::optional<iobuf> key,
-  model::timestamp ts,
-  model::timestamp_type ts_t,
-  const chunked_vector<model::record_header>& headers) {
-    auto system_data = std::make_unique<iceberg::struct_value>();
-    system_data->fields.reserve(6);
-
-    system_data->fields.emplace_back(iceberg::int_value(pid));
-    system_data->fields.emplace_back(iceberg::long_value(o));
-    system_data->fields.emplace_back(
-      iceberg::timestamptz_value(ts.value() * 1000));
-
-    if (headers.empty()) {
-        system_data->fields.emplace_back(std::nullopt);
-    } else {
-        auto headers_list = std::make_unique<iceberg::list_value>();
-        for (const auto& hdr : headers) {
-            auto header_kv_struct = std::make_unique<iceberg::struct_value>();
-            header_kv_struct->fields.emplace_back(
-              hdr.key_size() >= 0 ? std::make_optional<iceberg::value>(
-                                      iceberg::string_value(hdr.key().copy()))
-                                  : std::nullopt);
-            header_kv_struct->fields.emplace_back(
-              hdr.value_size() >= 0
-                ? std::make_optional<iceberg::value>(
-                    iceberg::binary_value(hdr.value().copy()))
-                : std::nullopt);
-            headers_list->elements.emplace_back(std::move(header_kv_struct));
-        }
-        system_data->fields.emplace_back(std::move(headers_list));
-    }
-
-    system_data->fields.emplace_back(
-      key ? std::make_optional<iceberg::value>(
-              iceberg::binary_value(std::move(*key)))
-          : std::nullopt);
-
-    system_data->fields.emplace_back(
-      iceberg::int_value{static_cast<int32_t>(ts_t)});
-
-    return system_data;
-}
-
 /// Find a field by name in a struct_type and return its index.
 std::optional<size_t>
 find_field_idx(const iceberg::struct_type& st, std::string_view name) {
@@ -219,11 +173,13 @@ debezium_envelope_to_table_type(const iceberg::struct_type& envelope_type) {
 
     for (auto& field : inner_type.fields) {
         if (field->name == rp_struct_name) {
-            auto& system_fields = std::get<iceberg::struct_type>(
-              ret_type.fields[0]->type);
+            auto& system_fields = rp_struct_type(ret_type);
             system_fields.fields.emplace_back(
               iceberg::nested_field::create(
-                10, "data", field->required, std::move(field->type)));
+                schemaless_next_field_id,
+                "data",
+                field->required,
+                std::move(field->type)));
             continue;
         }
         ret_type.fields.emplace_back(std::move(field));
@@ -409,10 +365,7 @@ debezium_translator::translate_data(
         for (size_t i = 0; i < inner->fields.size(); ++i) {
             auto& field = inner->fields[i];
             if (redpanda_field_idx == i) {
-                auto& system_vals
-                  = std::get<std::unique_ptr<iceberg::struct_value>>(
-                    ret_data.fields[0].value());
-                system_vals->fields.emplace_back(std::move(field));
+                rp_struct_value(ret_data).fields.emplace_back(std::move(field));
                 continue;
             }
             ret_data.fields.emplace_back(std::move(field));

--- a/src/v/datalake/record_multiplexer.cc
+++ b/src/v/datalake/record_multiplexer.cc
@@ -10,6 +10,7 @@
 #include "datalake/record_multiplexer.h"
 
 #include "base/vlog.h"
+#include "container/chunked_hash_map.h"
 #include "datalake/catalog_schema_manager.h"
 #include "datalake/data_writer_interface.h"
 #include "datalake/location.h"
@@ -20,6 +21,7 @@
 #include "datalake/table_id_provider.h"
 #include "datalake/translation/translation_probe.h"
 #include "features/feature_table.h"
+#include "iceberg/compatibility_utils.h"
 #include "model/batch_compression.h"
 #include "model/metadata.h"
 #include "model/record.h"
@@ -31,21 +33,87 @@ namespace datalake {
 
 namespace {
 
-/// Build a struct_type for just the key columns by extracting fields whose
-/// IDs match key_field_ids from the full type.
+/// Prune a struct_type to only contain the fields matching the given
+/// IDs, preserving the full nesting path from root to each selected
+/// field. This mirrors Iceberg's TypeUtil.select() behavior: if a
+/// selected field is nested inside a struct, the parent struct is
+/// included in the output with only the selected children.
 iceberg::struct_type extract_key_type(
   const iceberg::struct_type& full_type,
   const chunked_vector<iceberg::nested_field::id_t>& key_field_ids) {
-    iceberg::struct_type key_type;
-    for (const auto& key_id : key_field_ids) {
-        for (const auto& field : full_type.fields) {
-            if (field->id == key_id) {
-                key_type.fields.push_back(field->copy());
-                break;
+    chunked_hash_set<iceberg::nested_field::id_t> ids(
+      key_field_ids.begin(), key_field_ids.end());
+
+    // Recursive helper: prune a struct to only fields (or ancestors of
+    // fields) in the ID set. Returns nullopt if nothing in this subtree
+    // matches.
+    std::function<std::optional<iceberg::struct_type>(
+      const iceberg::struct_type&)>
+      prune = [&](const iceberg::struct_type& st)
+      -> std::optional<iceberg::struct_type> {
+        iceberg::struct_type result;
+        for (const auto& f : st.fields) {
+            if (ids.contains(f->id)) {
+                // This field is selected — include it as-is.
+                result.fields.push_back(f->copy());
+            } else if (
+              auto* nested_st = std::get_if<iceberg::struct_type>(&f->type)) {
+                // Check if any descendant is selected.
+                auto pruned = prune(*nested_st);
+                if (pruned.has_value()) {
+                    result.fields.push_back(
+                      iceberg::nested_field::create(
+                        f->id(),
+                        f->name,
+                        f->required,
+                        std::move(pruned.value())));
+                }
             }
         }
-    }
-    return key_type;
+        if (result.fields.empty()) {
+            return std::nullopt;
+        }
+        return result;
+    };
+
+    auto pruned = prune(full_type);
+    return pruned.has_value() ? std::move(pruned.value())
+                              : iceberg::struct_type{};
+}
+
+/// Nest a flat struct_value of key column values into the shape of the
+/// pruned key type. The flat struct has one field per leaf in the pruned
+/// type, in depth-first leaf order.
+///
+/// For top-level key fields (like debezium's `id`), the pruned type has
+/// no nesting and the flat values are returned as-is.
+iceberg::struct_value nest_key_value(
+  const iceberg::struct_type& pruned_type, iceberg::struct_value flat_values) {
+    size_t flat_idx = 0;
+
+    std::function<iceberg::struct_value(const iceberg::struct_type&)> build =
+      [&](const iceberg::struct_type& st) -> iceberg::struct_value {
+        iceberg::struct_value result;
+        for (const auto& f : st.fields) {
+            if (auto* nested_st = std::get_if<iceberg::struct_type>(&f->type)) {
+                auto nested_val = build(*nested_st);
+                result.fields.emplace_back(
+                  std::make_unique<iceberg::struct_value>(
+                    std::move(nested_val)));
+            } else {
+                if (flat_idx < flat_values.fields.size()) {
+                    result.fields.emplace_back(
+                      std::move(flat_values.fields[flat_idx]));
+                    ++flat_idx;
+                } else {
+                    result.fields.emplace_back(std::nullopt);
+                }
+            }
+        }
+        return result;
+    };
+
+    return build(pruned_type);
 }
 
 // Get the data location for the table. Some catalogs require using the property
@@ -360,13 +428,23 @@ ss::future<ss::stop_iteration> record_multiplexer::do_multiplex(
             if (record_type.key_field_names) {
                 // Resolve key field names to IDs using the type that
                 // fill_registered_ids just populated with catalog IDs.
+                // Names may be nested paths (e.g. "redpanda.key").
                 chunked_vector<iceberg::nested_field::id_t> key_ids;
                 for (const auto& name : *record_type.key_field_names) {
-                    for (const auto& f : data_writer->type().fields) {
-                        if (f->name == name) {
-                            key_ids.emplace_back(f->id);
+                    std::vector<ss::sstring> path;
+                    size_t pos = 0;
+                    while (pos < name.size()) {
+                        auto dot = name.find('.', pos);
+                        if (dot == ss::sstring::npos) {
+                            path.emplace_back(name.substr(pos));
                             break;
                         }
+                        path.emplace_back(name.substr(pos, dot - pos));
+                        pos = dot + 1;
+                    }
+                    auto* f = data_writer->type().find_field_by_name(path);
+                    if (f) {
+                        key_ids.emplace_back(f->id);
                     }
                 }
                 data_writer->set_key_field_ids(key_ids.copy());
@@ -405,15 +483,18 @@ ss::future<ss::stop_iteration> record_multiplexer::do_multiplex(
                 // partition source columns. Without this, equality
                 // deletes would be scoped to the wrong partition and
                 // fail to match the data files they intend to delete.
+                // Collect all field IDs in the pruned key type
+                // (including nested) for partition validation.
+                chunked_hash_set<iceberg::nested_field::id_t> key_field_id_set;
+                std::ignore = iceberg::for_each_field(
+                  key_type,
+                  [&key_field_id_set](const iceberg::nested_field* f) {
+                      key_field_id_set.insert(f->id);
+                  });
+
                 const auto& pspec = sw.data_writer->partition_spec();
                 for (const auto& pf : pspec.fields) {
-                    bool found = false;
-                    for (const auto& kf : key_type.fields) {
-                        if (kf->id == pf.source_id) {
-                            found = true;
-                            break;
-                        }
-                    }
+                    bool found = key_field_id_set.contains(pf.source_id);
                     if (!found) {
                         vlogl(
                           _log,
@@ -437,8 +518,13 @@ ss::future<ss::stop_iteration> record_multiplexer::do_multiplex(
                 delete_writer->set_key_field_ids(sw.key_field_ids->copy());
                 sw.delete_writer = std::move(delete_writer);
             }
+            // Nest the translator's flat key values into the pruned
+            // key type's structure so the delete file's Parquet
+            // schema matches the table schema's nesting.
+            auto nested_key = nest_key_value(
+              sw.delete_writer->type(), std::move(*translated.delete_key));
             auto add_del_result = co_await sw.delete_writer->add_data(
-              std::move(*translated.delete_key), estimated_size, as);
+              std::move(nested_key), estimated_size, as);
             if (add_del_result != writer_error::ok) {
                 vlogl(
                   _log,

--- a/src/v/datalake/schema_descriptor.h
+++ b/src/v/datalake/schema_descriptor.h
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "iceberg/datatypes.h"
+#include "iceberg/values.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <array>
+#include <cstddef>
+#include <optional>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+
+namespace datalake {
+
+/// A compile-time string usable as a template parameter (C++20 NTTP).
+template<size_t N>
+struct ct_string {
+    char data[N]{};
+    constexpr ct_string(const char (&s)[N]) { std::copy_n(s, N, data); }
+    constexpr operator std::string_view() const { return {data, N - 1}; }
+    constexpr auto operator<=>(const ct_string&) const = default;
+};
+
+/// A field descriptor: compile-time name + iceberg type.
+template<ct_string Name, typename T>
+struct field_desc {
+    static constexpr std::string_view name{Name};
+    using type = T;
+};
+
+/// Forward declarations.
+template<typename... Fields>
+struct struct_desc;
+
+template<typename ElementDesc>
+struct list_desc;
+
+/// Find the index of a field by name. Fails to compile if not found.
+template<ct_string Name, typename... Fields>
+consteval size_t index_of_fn() {
+    constexpr std::array names = {Fields::name...};
+    for (size_t i = 0; i < names.size(); ++i) {
+        if (names[i] == std::string_view{Name}) {
+            return i;
+        }
+    }
+    // If we reach here, the name was not found. This is consteval,
+    // so the compiler will reject it with an error pointing here.
+    throw "field name not found in descriptor";
+}
+
+/// Check that given names match field names in order.
+/// Uses an array of field names passed directly to avoid partial
+/// specialization.
+template<ct_string... Names>
+consteval bool
+names_match_fn(std::array<std::string_view, sizeof...(Names)> field_names) {
+    constexpr std::array given = {std::string_view{Names}...};
+    for (size_t i = 0; i < field_names.size(); ++i) {
+        if (field_names[i] != given[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/// A named value for use with struct_desc::build_value. The name is
+/// checked at compile time to match the corresponding field descriptor.
+template<ct_string Name>
+struct val {
+    std::optional<iceberg::value> v;
+
+    template<typename U>
+    requires std::constructible_from<std::optional<iceberg::value>, U>
+    val(U&& u) // NOLINT(google-explicit-constructor)
+      : v(std::forward<U>(u)) {}
+};
+
+template<typename... Fields>
+struct struct_desc {
+    static constexpr size_t count = sizeof...(Fields);
+
+    /// Compile-time index of a field by name.
+    template<ct_string Name>
+    static constexpr size_t index_of = index_of_fn<Name, Fields...>();
+
+    /// Total number of fields in the tree (used for ID assignment).
+    static int total_fields() {
+        int next_id = 0;
+        build_impl(next_id);
+        return next_id;
+    }
+
+    /// Build the runtime iceberg::struct_type.
+    static iceberg::struct_type build() {
+        int next_id = 0;
+        return build_impl(next_id);
+    }
+
+private:
+    template<typename...>
+    friend struct struct_desc;
+    template<typename>
+    friend struct list_desc;
+
+    static iceberg::struct_type build_impl(int& next_id) {
+        iceberg::struct_type st;
+        auto add = [&]<typename F>() {
+            int my_id = next_id++;
+            st.fields.push_back(
+              iceberg::nested_field::create(
+                my_id,
+                ss::sstring{F::name},
+                iceberg::field_required::no,
+                build_iceberg_type<F>(next_id)));
+        };
+        (add.template operator()<Fields>(), ...);
+        return st;
+    }
+
+public:
+    /// Build a struct_value with compile-time name and arity checking.
+    /// Each argument is a val<"field_name"> matching the descriptor.
+    ///
+    /// Wrong arity, wrong name, or wrong order = compile error.
+    template<ct_string... Names>
+    static std::unique_ptr<iceberg::struct_value>
+    build_value(val<Names>... args) {
+        static_assert(sizeof...(Names) == count, "wrong number of fields");
+        static_assert(
+          names_match_fn<Names...>({Fields::name...}),
+          "field names don't match descriptor or are in wrong order");
+        auto sv = std::make_unique<iceberg::struct_value>();
+        sv->fields.reserve(count);
+        (sv->fields.emplace_back(std::move(args.v)), ...);
+        return sv;
+    }
+
+private:
+    template<typename T>
+    static constexpr bool is_nested_v = false;
+    template<typename... Fs>
+    static constexpr bool is_nested_v<struct_desc<Fs...>> = true;
+    template<typename E>
+    static constexpr bool is_nested_v<list_desc<E>> = true;
+
+    template<typename F>
+    static auto build_iceberg_type(int& next_id) {
+        if constexpr (is_nested_v<typename F::type>) {
+            return F::type::build_impl(next_id);
+        } else {
+            return typename F::type{};
+        }
+    }
+};
+
+template<typename ElementDesc>
+struct list_desc;
+
+template<typename... Fields>
+struct list_desc<struct_desc<Fields...>> {
+    static iceberg::list_type build_impl(int& next_id) {
+        int element_id = next_id++;
+        return iceberg::list_type::create(
+          element_id,
+          iceberg::field_required::no,
+          struct_desc<Fields...>::build_impl(next_id));
+    }
+};
+
+template<typename Desc, ct_string Name>
+iceberg::nested_field& type_field(iceberg::struct_type& st) {
+    return *st.fields[Desc::template index_of<Name>];
+}
+
+template<typename Desc, ct_string Name>
+const iceberg::nested_field& type_field(const iceberg::struct_type& st) {
+    return *st.fields[Desc::template index_of<Name>];
+}
+
+template<typename Desc, ct_string Name>
+std::optional<iceberg::value>& value_field(iceberg::struct_value& sv) {
+    return sv.fields[Desc::template index_of<Name>];
+}
+
+template<typename Desc, ct_string Name>
+const std::optional<iceberg::value>&
+value_field(const iceberg::struct_value& sv) {
+    return sv.fields[Desc::template index_of<Name>];
+}
+
+} // namespace datalake

--- a/src/v/datalake/table_definition.cc
+++ b/src/v/datalake/table_definition.cc
@@ -10,52 +10,61 @@
 #include "datalake/table_definition.h"
 
 namespace datalake {
-using namespace iceberg;
-struct_type schemaless_struct_type() {
-    using namespace iceberg;
-    struct_type system_fields;
-    system_fields.fields.emplace_back(
-      nested_field::create(2, "partition", field_required::no, int_type{}));
-    system_fields.fields.emplace_back(
-      nested_field::create(3, "offset", field_required::no, long_type{}));
-    system_fields.fields.emplace_back(
-      nested_field::create(
-        4, "timestamp", field_required::no, timestamptz_type{}));
 
-    struct_type headers_kv;
-    headers_kv.fields.emplace_back(
-      nested_field::create(7, "key", field_required::no, string_type{}));
-    headers_kv.fields.emplace_back(
-      nested_field::create(8, "value", field_required::no, binary_type{}));
-    system_fields.fields.emplace_back(
-      nested_field::create(
-        5,
-        "headers",
-        field_required::no,
-        list_type::create(6, field_required::no, std::move(headers_kv))));
-
-    system_fields.fields.emplace_back(
-      nested_field::create(9, "key", field_required::no, binary_type{}));
-    system_fields.fields.emplace_back(
-      nested_field::create(
-        10, "timestamp_type", field_required::no, int_type{}));
-    struct_type res;
-    res.fields.emplace_back(
-      nested_field::create(
-        1,
-        ss::sstring{rp_struct_name},
-        field_required::no,
-        std::move(system_fields)));
-
-    return res;
+iceberg::struct_type schemaless_struct_type() {
+    return schemaless_desc::build();
 }
 
-schema default_schema() {
-    return {
+iceberg::schema default_schema() {
+    return iceberg::schema{
       .schema_struct = schemaless_struct_type(),
-      .schema_id = iceberg::schema::id_t{0},
+      .schema_id = iceberg::schema::default_id,
       .identifier_field_ids = {},
     };
+}
+
+namespace {
+
+std::optional<iceberg::value>
+build_headers_value(const chunked_vector<model::record_header>& headers) {
+    if (headers.empty()) {
+        return std::nullopt;
+    }
+    auto hdr_list = std::make_unique<iceberg::list_value>();
+    for (const auto& hdr : headers) {
+        auto kv = header_kv_desc::build_value(
+          val<"key">(
+            hdr.key_size() >= 0 ? std::make_optional<iceberg::value>(
+                                    iceberg::string_value(hdr.key().copy()))
+                                : std::nullopt),
+          val<"value">(
+            hdr.value_size() >= 0 ? std::make_optional<iceberg::value>(
+                                      iceberg::binary_value(hdr.value().copy()))
+                                  : std::nullopt));
+        hdr_list->elements.emplace_back(std::move(kv));
+    }
+    return hdr_list;
+}
+
+} // namespace
+
+std::unique_ptr<iceberg::struct_value> build_rp_struct(
+  model::partition_id pid,
+  kafka::offset o,
+  std::optional<iobuf> key,
+  model::timestamp ts,
+  model::timestamp_type ts_t,
+  const chunked_vector<model::record_header>& headers) {
+    return rp_desc::build_value(
+      val<"partition">(iceberg::int_value(pid)),
+      val<"offset">(iceberg::long_value(o)),
+      val<"timestamp">(iceberg::timestamptz_value(ts.value() * 1000)),
+      val<"headers">(build_headers_value(headers)),
+      val<"key">(
+        key ? std::make_optional<iceberg::value>(
+                iceberg::binary_value(std::move(*key)))
+            : std::nullopt),
+      val<"timestamp_type">(iceberg::int_value{static_cast<int32_t>(ts_t)}));
 }
 
 } // namespace datalake

--- a/src/v/datalake/table_definition.h
+++ b/src/v/datalake/table_definition.h
@@ -9,16 +9,70 @@
  */
 #pragma once
 
+#include "datalake/schema_descriptor.h"
 #include "iceberg/schema.h"
+#include "model/fundamental.h"
+#include "model/record.h"
+#include "model/timestamp.h"
 
 namespace datalake {
 
-// Definitions for default table metadata.
+// The schema is defined once here as a type. All field ordering,
+// naming, and type information is derived from this single source.
+// Adding, removing, or reordering fields here automatically updates:
+//   - schemaless_struct_type() (runtime struct_type)
+//   - build_rp_struct() (runtime struct_value)
+//   - All typed field accessors
 
-// Contains some minimal fields used for all tables, even those with no schemas.
-// TODO: rename to redpanda_fields_struct_type?
-iceberg::struct_type schemaless_struct_type();
-iceberg::schema default_schema();
+/// Header key/value struct inside the headers list.
+using header_kv_desc = struct_desc<
+  field_desc<"key", iceberg::string_type>,
+  field_desc<"value", iceberg::binary_type>>;
+
+/// The redpanda system struct.
+using rp_desc = struct_desc<
+  field_desc<"partition", iceberg::int_type>,
+  field_desc<"offset", iceberg::long_type>,
+  field_desc<"timestamp", iceberg::timestamptz_type>,
+  field_desc<"headers", list_desc<header_kv_desc>>,
+  field_desc<"key", iceberg::binary_type>,
+  field_desc<"timestamp_type", iceberg::int_type>>;
+
+/// The top-level schemaless table struct.
+using schemaless_desc = struct_desc<field_desc<"redpanda", rp_desc>>;
+
 inline constexpr std::string_view rp_struct_name = "redpanda";
+
+/// Next available pre-assignment field ID after the schemaless struct.
+/// Translators that add fields should start IDs from here.
+inline const int schemaless_next_field_id = schemaless_desc::total_fields();
+
+/// Build the runtime struct_type from the compile-time descriptor.
+iceberg::struct_type schemaless_struct_type();
+
+/// Build the default iceberg schema.
+iceberg::schema default_schema();
+
+/// Build the redpanda system struct_value. Single definition used
+/// by all translators.
+std::unique_ptr<iceberg::struct_value> build_rp_struct(
+  model::partition_id pid,
+  kafka::offset o,
+  std::optional<iobuf> key,
+  model::timestamp ts,
+  model::timestamp_type ts_t,
+  const chunked_vector<model::record_header>& headers);
+
+/// Get the redpanda struct_type from a schemaless struct_type.
+inline iceberg::struct_type& rp_struct_type(iceberg::struct_type& schemaless) {
+    return std::get<iceberg::struct_type>(
+      type_field<schemaless_desc, "redpanda">(schemaless).type);
+}
+
+/// Get the redpanda struct_value from a data row.
+inline iceberg::struct_value& rp_struct_value(iceberg::struct_value& row) {
+    return *std::get<std::unique_ptr<iceberg::struct_value>>(
+      value_field<schemaless_desc, "redpanda">(row).value());
+}
 
 } // namespace datalake

--- a/src/v/iceberg/datatypes.cc
+++ b/src/v/iceberg/datatypes.cc
@@ -330,6 +330,7 @@ const nested_field* struct_type::find_field_by_name(
             return nullptr;
         }
 
+        field = nullptr;
         for (const auto& f : cur_struct_type->fields) {
             if (f->name == n) {
                 field = f.get();

--- a/src/v/iceberg/manifest_io.cc
+++ b/src/v/iceberg/manifest_io.cc
@@ -102,4 +102,16 @@ manifest_io::download_object_bytes(const uri& uri) {
       path_res.value(), "iceberg::data_file", [](iobuf buf) { return buf; });
 }
 
+ss::future<checked<size_t, metadata_io::errc>>
+manifest_io::upload_object_bytes(const uri& uri, iobuf data) {
+    auto path_res = from_uri(uri);
+    if (path_res.has_error()) {
+        co_return path_res.error();
+    }
+    co_return co_await upload_object<iobuf>(
+      path_res.value(), data, "iceberg::data_file", [](const iobuf& buf) {
+          return buf.copy();
+      });
+}
+
 } // namespace iceberg

--- a/src/v/iceberg/manifest_io.h
+++ b/src/v/iceberg/manifest_io.h
@@ -57,6 +57,9 @@ public:
 
     ss::future<checked<iobuf, metadata_io::errc>>
     download_object_bytes(const uri& uri);
+
+    ss::future<checked<size_t, metadata_io::errc>>
+    upload_object_bytes(const uri& uri, iobuf data);
 };
 
 } // namespace iceberg

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -679,6 +679,10 @@ public:
         // user.
         value_schema_latest = 3,
         debezium = 4,
+        // Like key_value but with CDC semantics: every record produces
+        // an equality delete for its key, and tombstones (null value)
+        // are treated as pure deletes.
+        cdc_key_value = 5,
     };
     static iceberg_mode disabled;
 
@@ -687,6 +691,8 @@ public:
     static iceberg_mode value_schema_id_prefix;
 
     static iceberg_mode debezium;
+
+    static iceberg_mode cdc_key_value;
 
     // Creates a new iceberg mode with the latest protobuf value kind and the
     // protobuf full name.
@@ -767,13 +773,17 @@ private:
     struct debezium_impl {
         bool operator==(const debezium_impl&) const = default;
     };
+    struct cdc_key_value_impl {
+        bool operator==(const cdc_key_value_impl&) const = default;
+    };
 
     std::variant<
       disabled_impl,
       key_value_impl,
       value_schema_id_prefix_impl,
       value_schema_latest_impl,
-      debezium_impl>
+      debezium_impl,
+      cdc_key_value_impl>
       _impl;
 };
 

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -660,6 +660,8 @@ iceberg_mode iceberg_mode::value_schema_id_prefix
   = iceberg_mode::make<iceberg_mode::variant::value_schema_id_prefix>();
 iceberg_mode iceberg_mode::debezium
   = iceberg_mode::make<iceberg_mode::variant::debezium>();
+iceberg_mode iceberg_mode::cdc_key_value
+  = iceberg_mode::make<iceberg_mode::variant::cdc_key_value>();
 
 void write_nested(iobuf& out, const iceberg_mode& m) {
     using serde::write;
@@ -696,6 +698,9 @@ void read_nested(
     case iceberg_mode::variant::debezium:
         m = iceberg_mode::debezium;
         return;
+    case iceberg_mode::variant::cdc_key_value:
+        m = iceberg_mode::cdc_key_value;
+        return;
     }
     throw serde::serde_exception(
       fmt::format("unknown iceberg_mode variant: {}", std::to_underlying(v)));
@@ -728,6 +733,8 @@ std::ostream& operator<<(std::ostream& os, const iceberg_mode& mode) {
     }
     case iceberg_mode::variant::debezium:
         return os << "debezium_schema_id_prefix";
+    case iceberg_mode::variant::cdc_key_value:
+        return os << "cdc_key_value";
     }
 }
 
@@ -773,6 +780,8 @@ std::istream& operator>>(std::istream& is, iceberg_mode& mode) {
         mode = iceberg_mode::value_schema_id_prefix;
     } else if (s == "debezium_schema_id_prefix") {
         mode = iceberg_mode::debezium;
+    } else if (s == "cdc_key_value") {
+        mode = iceberg_mode::cdc_key_value;
     } else if (s.starts_with("value_schema_latest")) {
         s = s.substr(std::strlen("value_schema_latest"));
         auto options = parse_config_options(s);

--- a/tests/rptest/tests/datalake/cdc_key_value_test.py
+++ b/tests/rptest/tests/datalake/cdc_key_value_test.py
@@ -1,0 +1,109 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+"""Test for cdc_key_value iceberg mode.
+
+Verifies that records with keys produce equality deletes, and
+tombstones (null value) are treated as pure deletes.
+"""
+
+from ducktape.mark import matrix
+from ducktape.utils.util import wait_until
+
+from rptest.clients.rpk import RpkTool
+from rptest.clients.types import TopicSpec
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import SISettings, SchemaRegistryConfig
+from rptest.tests.datalake.datalake_services import DatalakeServices
+from rptest.tests.datalake.query_engine_base import QueryEngineType
+from rptest.tests.datalake.utils import supported_storage_types
+from rptest.tests.redpanda_test import RedpandaTest
+
+TOPIC = "cdc-kv-test"
+
+
+class CdcKeyValueTest(RedpandaTest):
+    """Tests for cdc_key_value iceberg mode."""
+
+    def __init__(self, test_ctx):
+        super().__init__(
+            test_ctx,
+            num_brokers=1,
+            si_settings=SISettings(test_context=test_ctx),
+            schema_registry_config=SchemaRegistryConfig(),
+            extra_rp_conf={
+                "iceberg_enabled": True,
+                "iceberg_catalog_commit_interval_ms": 5000,
+            },
+        )
+        self.dl = DatalakeServices(
+            self.test_context,
+            redpanda=self.redpanda,
+            include_query_engines=[QueryEngineType.SPARK],
+        )
+
+    def setUp(self):
+        self.dl.setUp()
+
+    def tearDown(self):
+        self.dl.tearDown()
+        super().tearDown()
+
+    @cluster(num_nodes=3)
+    @matrix(cloud_storage_type=supported_storage_types())
+    def test_cdc_key_value_upsert_delete(self, cloud_storage_type):
+        """Insert, update (overwrite key), and delete (tombstone)."""
+        self.dl.create_iceberg_enabled_topic(
+            TOPIC,
+            iceberg_mode="cdc_key_value",
+            config={
+                TopicSpec.PROPERTY_ICEBERG_PARTITION_SPEC: "(identity(redpanda.key))",
+            },
+        )
+
+        rpk = RpkTool(self.redpanda)
+
+        # Insert three records.
+        rpk.produce(TOPIC, key="k1", msg="alice")
+        rpk.produce(TOPIC, key="k2", msg="bob")
+        rpk.produce(TOPIC, key="k3", msg="charlie")
+
+        self.dl.wait_for_translation(TOPIC, msg_count=3)
+
+        # Update k1 (produces equality delete for k1 + new data row).
+        rpk.produce(TOPIC, key="k1", msg="alicia")
+        # Delete k2 via tombstone.
+        rpk.produce(TOPIC, key="k2", msg="", tombstone=True)
+
+        spark = self.dl.query_engine(QueryEngineType.SPARK)
+        tbl = f"redpanda.{spark.escape_identifier(TOPIC)}"
+
+        def _check():
+            try:
+                rows = spark.run_query_fetch_all(
+                    f"SELECT redpanda.key, value FROM {tbl} ORDER BY redpanda.key"
+                )
+                self.logger.info(f"Rows: {rows}")
+                # k1 updated to 'alicia', k2 deleted, k3 unchanged.
+                # Key and value are binary; Spark returns them as bytes.
+                expected = [
+                    (bytearray(b"k1"), bytearray(b"alicia")),
+                    (bytearray(b"k3"), bytearray(b"charlie")),
+                ]
+                return rows == expected
+            except Exception as e:
+                self.logger.info(f"Query failed: {e}")
+                return False
+
+        wait_until(
+            _check,
+            timeout_sec=120,
+            backoff_sec=5,
+            err_msg="CDC final state not reflected in Iceberg",
+        )


### PR DESCRIPTION
## Summary
- Compile-time schema descriptors for typed translator schema access
- cdc_key_value translator and iceberg mode for simple key-value CDC
- Coordinator converts equality deletes to position deletes before commit
- E2E test verifying upsert/delete semantics via Spark

Stack: 5/6 (depends on #9)