### PR TITLE
iceberg: add VARIANT type with parquet schema mapping

### DIFF
--- a/src/v/iceberg/conversion/schema_parquet.cc
+++ b/src/v/iceberg/conversion/schema_parquet.cc
@@ -10,6 +10,7 @@
 
 #include "iceberg/datatypes.h"
 #include "serde/parquet/schema.h"
+#include "serde/parquet/variant_schema.h"
 
 namespace iceberg {
 namespace {
@@ -112,6 +113,12 @@ struct primitive_type_converting_visitor {
         return serde::parquet::schema_element{
           .type = serde::parquet::byte_array_type{},
         };
+    }
+    serde::parquet::schema_element operator()(const iceberg::variant_type&) {
+        auto res = serde::parquet::build_variant_schema(
+          "", serde::parquet::field_repetition_type::optional);
+        res.path.clear();
+        return res;
     }
 };
 

--- a/src/v/iceberg/datatypes.cc
+++ b/src/v/iceberg/datatypes.cc
@@ -195,6 +195,11 @@ std::ostream& operator<<(std::ostream& o, const binary_type&) {
     return o;
 }
 
+std::ostream& operator<<(std::ostream& o, const variant_type&) {
+    o << "variant";
+    return o;
+}
+
 std::ostream& operator<<(std::ostream& o, const struct_type& st) {
     /**
      * Struct is printed as struct[field_1_name<field_1_type>,...]

--- a/src/v/iceberg/datatypes.h
+++ b/src/v/iceberg/datatypes.h
@@ -39,6 +39,9 @@ struct fixed_type {
     uint64_t length;
 };
 struct binary_type {};
+struct variant_type {
+    friend bool operator==(const variant_type&, const variant_type&) = default;
+};
 using primitive_type = std::variant<
   boolean_type,
   int_type,
@@ -53,7 +56,8 @@ using primitive_type = std::variant<
   string_type,
   uuid_type,
   fixed_type,
-  binary_type>;
+  binary_type,
+  variant_type>;
 bool operator==(const primitive_type& lhs, const primitive_type& rhs);
 
 struct struct_type;
@@ -79,6 +83,7 @@ std::ostream& operator<<(std::ostream&, const string_type&);
 std::ostream& operator<<(std::ostream&, const uuid_type&);
 std::ostream& operator<<(std::ostream&, const fixed_type&);
 std::ostream& operator<<(std::ostream&, const binary_type&);
+std::ostream& operator<<(std::ostream&, const variant_type&);
 std::ostream& operator<<(std::ostream&, const struct_type&);
 std::ostream& operator<<(std::ostream&, const list_type&);
 std::ostream& operator<<(std::ostream&, const map_type&);

--- a/src/v/iceberg/datatypes_json.cc
+++ b/src/v/iceberg/datatypes_json.cc
@@ -112,7 +112,8 @@ field_type parse_type(const json::Value& v) {
           .match("timestamptz", timestamptz_type{})
           .match("string", string_type{})
           .match("uuid", uuid_type{})
-          .match("binary", binary_type{});
+          .match("binary", binary_type{})
+          .match("variant", variant_type{});
     }
     if (!v.IsObject()) {
         throw std::invalid_argument("Expected string or object for type field");
@@ -159,6 +160,7 @@ public:
         w.String(fmt::format("fixed[{}]", t.length));
     }
     void operator()(const iceberg::binary_type&) { w.String("binary"); }
+    void operator()(const iceberg::variant_type&) { w.String("variant"); }
 
     void operator()(const iceberg::primitive_type& t) { rjson_serialize(w, t); }
     void operator()(const iceberg::struct_type& t) { rjson_serialize(w, t); }

--- a/src/v/iceberg/tests/BUILD
+++ b/src/v/iceberg/tests/BUILD
@@ -755,32 +755,34 @@ redpanda_cc_bench(
 )
 
 redpanda_cc_gtest(
-    name = "row_operations_test",
+    name = "position_delete_file_test",
     timeout = "short",
     srcs = [
-        "row_operations_test.cc",
+        "position_delete_file_test.cc",
     ],
-    cpu = 1,
     deps = [
-        "//src/v/bytes:iostream",
-        "//src/v/cloud_io:remote",
-        "//src/v/cloud_io/tests:s3_imposter",
-        "//src/v/cloud_io/tests:scoped_remote",
-        "//src/v/container:chunked_hash_map",
-        "//src/v/iceberg:manifest_io",
-        "//src/v/iceberg:merge_append_action",
-        "//src/v/iceberg:partition",
-        "//src/v/iceberg:row_operations",
-        "//src/v/iceberg:table_update",
-        "//src/v/iceberg:table_update_applier",
+        "//src/v/iceberg:partition_key",
+        "//src/v/iceberg:position_delete_file",
         "//src/v/iceberg:values",
-        "//src/v/model",
         "//src/v/serde/parquet:reader",
         "//src/v/serde/parquet:value",
-        "//src/v/serde/parquet:writer",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",
-        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "equality_delete_file_test",
+    timeout = "short",
+    srcs = [
+        "equality_delete_file_test.cc",
+    ],
+    deps = [
+        "//src/v/iceberg:equality_delete_file",
+        "//src/v/serde/parquet:reader",
+        "//src/v/serde/parquet:value",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
     ],
 )
 
@@ -807,32 +809,32 @@ redpanda_cc_gtest(
 )
 
 redpanda_cc_gtest(
-    name = "position_delete_file_test",
+    name = "row_operations_test",
     timeout = "short",
     srcs = [
-        "position_delete_file_test.cc",
+        "row_operations_test.cc",
     ],
+    cpu = 1,
     deps = [
-        "//src/v/iceberg:position_delete_file",
+        "//src/v/bytes:iostream",
+        "//src/v/cloud_io:remote",
+        "//src/v/cloud_io/tests:s3_imposter",
+        "//src/v/cloud_io/tests:scoped_remote",
+        "//src/v/container:chunked_hash_map",
+        "//src/v/iceberg:manifest_io",
+        "//src/v/iceberg:merge_append_action",
+        "//src/v/iceberg:partition",
+        "//src/v/iceberg:row_operations",
+        "//src/v/iceberg:table_update",
+        "//src/v/iceberg:table_update_applier",
+        "//src/v/iceberg:values",
+        "//src/v/model",
         "//src/v/serde/parquet:reader",
         "//src/v/serde/parquet:value",
+        "//src/v/serde/parquet:writer",
         "//src/v/test_utils:gtest",
         "@googletest//:gtest",
-    ],
-)
-
-redpanda_cc_gtest(
-    name = "equality_delete_file_test",
-    timeout = "short",
-    srcs = [
-        "equality_delete_file_test.cc",
-    ],
-    deps = [
-        "//src/v/iceberg:equality_delete_file",
-        "//src/v/serde/parquet:reader",
-        "//src/v/serde/parquet:value",
-        "//src/v/test_utils:gtest",
-        "@googletest//:gtest",
+        "@seastar",
     ],
 )
 

--- a/src/v/serde/parquet/metadata.cc
+++ b/src/v/serde/parquet/metadata.cc
@@ -225,6 +225,7 @@ iobuf encode(const flattened_schema& schema, bool is_root) {
         bson = 13,
         uuid = 14,
         float16 = 15,
+        variant = 16,
     };
 
     thrift::struct_encoder logical_type_encoder;
@@ -291,6 +292,12 @@ iobuf encode(const flattened_schema& schema, bool is_root) {
       [&](const f16_type&) {
           logical_type_encoder.write_field(
             thrift::field_id(logical_type::float16),
+            thrift::field_type::structure,
+            thrift::struct_encoder::empty_struct);
+      },
+      [&](const variant_type&) {
+          logical_type_encoder.write_field(
+            thrift::field_id(logical_type::variant),
             thrift::field_type::structure,
             thrift::struct_encoder::empty_struct);
       },
@@ -1048,6 +1055,7 @@ logical_type decode_logical_type(iobuf_parser_base& parser) {
         bson = 13,
         uuid = 14,
         float16 = 15,
+        variant = 16,
     };
 
     logical_type result;
@@ -1171,6 +1179,10 @@ logical_type decode_logical_type(iobuf_parser_base& parser) {
             break;
         case logical_type_id::float16:
             result = f16_type();
+            dec.skip_field(hdr->type);
+            break;
+        case logical_type_id::variant:
+            result = variant_type();
             dec.skip_field(hdr->type);
             break;
         default:

--- a/src/v/serde/parquet/schema.h
+++ b/src/v/serde/parquet/schema.h
@@ -108,6 +108,10 @@ struct date_type {
 struct f16_type {
     bool operator==(const f16_type&) const = default;
 };
+// Parquet VARIANT logical type (V3 placeholder, field ID may change)
+struct variant_type {
+    bool operator==(const variant_type&) const = default;
+};
 
 /**
  * Logical type to annotate a column that is always null.
@@ -226,12 +230,13 @@ using logical_type = std::variant<
   // use ConvertedType TIMESTAMP_MILLIS for
   // TIMESTAMP(isAdjustedToUTC=*, unit=MILLIS)
   timestamp_type,
-  int_type,  // use ConvertedType INT_* or UINT_*
-  null_type, // no compatible ConvertedType
-  json_type, // use ConvertedType JSON
-  bson_type, // use ConvertedType BSON
-  uuid_type, // no compatible ConvertedType
-  f16_type>; // no compatible ConvertedType
+  int_type,      // use ConvertedType INT_* or UINT_*
+  null_type,     // no compatible ConvertedType
+  json_type,     // use ConvertedType JSON
+  bson_type,     // use ConvertedType BSON
+  uuid_type,     // no compatible ConvertedType
+  f16_type,      // no compatible ConvertedType
+  variant_type>; // no compatible ConvertedType
 
 /**
  * Represents a element inside a schema definition.

--- a/src/v/serde/parquet/tests/BUILD
+++ b/src/v/serde/parquet/tests/BUILD
@@ -288,6 +288,93 @@ write_file(
 ]
 
 redpanda_cc_gtest(
+    name = "variant_encoding_test",
+    timeout = "short",
+    srcs = ["variant_encoding_test.cc"],
+    cpu = 1,
+    memory = "128MiB",
+    deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/bytes:iobuf_parser",
+        "//src/v/serde/parquet:variant_encoding",
+        "//src/v/serde/parquet:variant_value",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "variant_value_test",
+    timeout = "short",
+    srcs = ["variant_value_test.cc"],
+    cpu = 1,
+    memory = "64MiB",
+    deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/serde/parquet:variant_value",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "variant_shredder_test",
+    timeout = "short",
+    srcs = ["variant_shredder_test.cc"],
+    cpu = 1,
+    memory = "64MiB",
+    deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/serde/parquet:variant_shredder",
+        "//src/v/serde/parquet:variant_value",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "variant_json_test",
+    timeout = "short",
+    srcs = ["variant_json_test.cc"],
+    cpu = 1,
+    memory = "64MiB",
+    deps = [
+        "//src/v/bytes:iobuf",
+        "//src/v/serde/parquet:variant_encoding",
+        "//src/v/serde/parquet:variant_json",
+        "//src/v/serde/parquet:variant_value",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
+    name = "variant_integration_test",
+    timeout = "short",
+    srcs = ["variant_integration_test.cc"],
+    cpu = 1,
+    memory = "128MiB",
+    deps = [
+        "//src/v/bytes:iostream",
+        "//src/v/serde/parquet:reader",
+        "//src/v/serde/parquet:schema",
+        "//src/v/serde/parquet:value",
+        "//src/v/serde/parquet:variant_encoding",
+        "//src/v/serde/parquet:variant_json",
+        "//src/v/serde/parquet:variant_schema",
+        "//src/v/serde/parquet:variant_value",
+        "//src/v/serde/parquet:writer",
+        "//src/v/test_utils:gtest",
+        "@googletest//:gtest",
+        "@seastar",
+    ],
+)
+
+redpanda_cc_gtest(
     name = "encoding_test",
     timeout = "short",
     srcs = [

--- a/src/v/serde/parquet/tests/variant_encoding_test.cc
+++ b/src/v/serde/parquet/tests/variant_encoding_test.cc
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "bytes/iobuf.h"
+#include "bytes/iobuf_parser.h"
+#include "serde/parquet/variant_encoding.h"
+#include "serde/parquet/variant_value.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+using namespace serde::parquet;
+
+namespace {
+
+void round_trip(const variant_value& input) {
+    auto encoded = encode_variant(input);
+    auto decoded = decode_variant(encoded.metadata, encoded.value);
+    EXPECT_TRUE(input == decoded);
+}
+
+} // namespace
+
+TEST(VariantEncoding, Null) { round_trip(null_value{}); }
+
+TEST(VariantEncoding, True) { round_trip(boolean_value{.val = true}); }
+
+TEST(VariantEncoding, False) { round_trip(boolean_value{.val = false}); }
+
+TEST(VariantEncoding, Int32) { round_trip(int32_value{.val = -42}); }
+
+TEST(VariantEncoding, Int32Zero) { round_trip(int32_value{.val = 0}); }
+
+TEST(VariantEncoding, Int32Max) {
+    round_trip(int32_value{.val = std::numeric_limits<int32_t>::max()});
+}
+
+TEST(VariantEncoding, Int64) {
+    round_trip(int64_value{.val = 1234567890123LL});
+}
+
+TEST(VariantEncoding, Int64Negative) {
+    round_trip(int64_value{.val = -9876543210LL});
+}
+
+TEST(VariantEncoding, Float32) { round_trip(float32_value{.val = 3.14f}); }
+
+TEST(VariantEncoding, Float32NegZero) {
+    round_trip(float32_value{.val = -0.0f});
+}
+
+TEST(VariantEncoding, Float64) {
+    round_trip(float64_value{.val = 2.718281828459045});
+}
+
+TEST(VariantEncoding, Float64Infinity) {
+    round_trip(float64_value{.val = std::numeric_limits<double>::infinity()});
+}
+
+TEST(VariantEncoding, ShortStringEmpty) {
+    round_trip(variant_string_value{.val = ""});
+}
+
+TEST(VariantEncoding, ShortString) {
+    round_trip(variant_string_value{.val = "hello world"});
+}
+
+TEST(VariantEncoding, ShortStringMax63) {
+    // 63-byte string encodes as short_string
+    std::string s(63, 'x');
+    round_trip(variant_string_value{.val = ss::sstring(s)});
+}
+
+TEST(VariantEncoding, LongString64) {
+    // 64-byte string encodes as primitive string
+    std::string s(64, 'y');
+    round_trip(variant_string_value{.val = ss::sstring(s)});
+}
+
+TEST(VariantEncoding, LongStringLarge) {
+    std::string s(1000, 'z');
+    round_trip(variant_string_value{.val = ss::sstring(s)});
+}
+
+TEST(VariantEncoding, BinaryEmpty) {
+    iobuf buf;
+    round_trip(byte_array_value{.val = std::move(buf)});
+}
+
+TEST(VariantEncoding, BinaryData) {
+    iobuf buf;
+    buf.append("\x00\x01\x02\xff", 4);
+    round_trip(byte_array_value{.val = std::move(buf)});
+}
+
+TEST(VariantEncoding, EmptyObject) {
+    auto obj = std::make_unique<variant_object>();
+    round_trip(std::move(obj));
+}
+
+TEST(VariantEncoding, ObjectWithFields) {
+    auto obj = std::make_unique<variant_object>();
+    obj->fields.emplace_back("name", variant_string_value{.val = "alice"});
+    obj->fields.emplace_back("age", int32_value{.val = 30});
+    obj->fields.emplace_back("active", boolean_value{.val = true});
+    sort_variant_object(*obj);
+    round_trip(std::move(obj));
+}
+
+TEST(VariantEncoding, EmptyArray) {
+    auto arr = std::make_unique<variant_array>();
+    round_trip(std::move(arr));
+}
+
+TEST(VariantEncoding, ArrayMixedTypes) {
+    auto arr = std::make_unique<variant_array>();
+    arr->elements.emplace_back(int32_value{.val = 1});
+    arr->elements.emplace_back(variant_string_value{.val = "two"});
+    arr->elements.emplace_back(boolean_value{.val = false});
+    arr->elements.emplace_back(null_value{});
+    arr->elements.emplace_back(float64_value{.val = 4.0});
+    round_trip(std::move(arr));
+}
+
+TEST(VariantEncoding, NestedObjectArrayObject) {
+    // { "items": [ { "id": 1 }, { "id": 2 } ] }
+    auto inner1 = std::make_unique<variant_object>();
+    inner1->fields.emplace_back("id", int32_value{.val = 1});
+
+    auto inner2 = std::make_unique<variant_object>();
+    inner2->fields.emplace_back("id", int32_value{.val = 2});
+
+    auto arr = std::make_unique<variant_array>();
+    arr->elements.emplace_back(std::move(inner1));
+    arr->elements.emplace_back(std::move(inner2));
+
+    auto outer = std::make_unique<variant_object>();
+    outer->fields.emplace_back("items", std::move(arr));
+
+    round_trip(std::move(outer));
+}
+
+TEST(VariantEncoding, DictionarySortedDeduplicated) {
+    // Object with keys "b", "a", "b" should produce dictionary ["a", "b"]
+    auto obj = std::make_unique<variant_object>();
+    obj->fields.emplace_back("b", int32_value{.val = 1});
+    obj->fields.emplace_back("a", int32_value{.val = 2});
+    obj->fields.emplace_back("b", int32_value{.val = 3});
+
+    auto encoded = encode_variant(variant_value{std::move(obj)});
+
+    // Parse the metadata to verify dictionary contents.
+    iobuf_const_parser p(encoded.metadata);
+    uint8_t header = p.consume_type<uint8_t>();
+    uint8_t offset_size = static_cast<uint8_t>(((header >> 5) & 0x03) + 1);
+    uint8_t raw[4] = {};
+    p.consume_to(offset_size, raw);
+    uint32_t dict_size = 0;
+    std::memcpy(&dict_size, raw, 4);
+    EXPECT_EQ(dict_size, 2);
+
+    // Read offsets
+    chunked_vector<uint32_t> offsets;
+    for (uint32_t i = 0; i <= dict_size; ++i) {
+        uint8_t obuf[4] = {};
+        p.consume_to(offset_size, obuf);
+        uint32_t val = 0;
+        std::memcpy(&val, obuf, 4);
+        offsets.push_back(val);
+    }
+
+    // Read strings
+    chunked_vector<ss::sstring> strings;
+    for (uint32_t i = 0; i < dict_size; ++i) {
+        uint32_t len = offsets[i + 1] - offsets[i];
+        strings.push_back(p.read_string_unsafe(len));
+    }
+
+    ASSERT_EQ(strings.size(), 2);
+    EXPECT_EQ(strings[0], "a");
+    EXPECT_EQ(strings[1], "b");
+}
+
+TEST(VariantEncoding, DeeplyNested) {
+    // Array of arrays of objects
+    auto obj1 = std::make_unique<variant_object>();
+    obj1->fields.emplace_back("x", int64_value{.val = 100});
+
+    auto inner_arr = std::make_unique<variant_array>();
+    inner_arr->elements.emplace_back(std::move(obj1));
+    inner_arr->elements.emplace_back(variant_string_value{.val = "inner"});
+
+    auto outer_arr = std::make_unique<variant_array>();
+    outer_arr->elements.emplace_back(std::move(inner_arr));
+    outer_arr->elements.emplace_back(int32_value{.val = 42});
+
+    round_trip(std::move(outer_arr));
+}
+
+TEST(VariantEncoding, ObjectFieldOrderPreserved) {
+    auto obj = std::make_unique<variant_object>();
+    obj->fields.emplace_back("z", int32_value{.val = 1});
+    obj->fields.emplace_back("a", int32_value{.val = 2});
+    obj->fields.emplace_back("m", int32_value{.val = 3});
+
+    auto encoded = encode_variant(variant_value{std::move(obj)});
+    auto decoded = decode_variant(encoded.metadata, encoded.value);
+
+    const auto& dec_obj = *std::get<std::unique_ptr<variant_object>>(decoded);
+    ASSERT_EQ(dec_obj.fields.size(), 3);
+    EXPECT_EQ(dec_obj.fields[0].first, "z");
+    EXPECT_EQ(dec_obj.fields[1].first, "a");
+    EXPECT_EQ(dec_obj.fields[2].first, "m");
+}

--- a/src/v/serde/parquet/tests/variant_integration_test.cc
+++ b/src/v/serde/parquet/tests/variant_integration_test.cc
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "bytes/iostream.h"
+#include "serde/parquet/reader.h"
+#include "serde/parquet/schema.h"
+#include "serde/parquet/value.h"
+#include "serde/parquet/variant_encoding.h"
+#include "serde/parquet/variant_json.h"
+#include "serde/parquet/variant_schema.h"
+#include "serde/parquet/variant_value.h"
+#include "serde/parquet/writer.h"
+
+#include <gtest/gtest.h>
+
+namespace serde::parquet {
+
+namespace {
+
+schema_element make_root(schema_element child) {
+    schema_element root{
+      .repetition_type = field_repetition_type::required,
+      .path = {"root"},
+    };
+    root.children.push_back(std::move(child));
+    return root;
+}
+
+iobuf write_single_row(schema_element schema, group_value row) {
+    group_value top;
+    top.push_back(group_member{value{std::move(row)}});
+    iobuf file;
+    writer w({.schema = std::move(schema)}, make_iobuf_ref_output_stream(file));
+    w.init().get();
+    w.write_row(std::move(top)).get();
+    w.close().get();
+    return file;
+}
+
+} // namespace
+
+// NOLINTBEGIN(*magic-number*)
+
+TEST(VariantIntegration, UnshredddedWriteRead) {
+    auto json = iobuf::from(R"({"name":"alice","age":30})");
+    auto val = parse_json_to_variant(std::move(json)).get();
+
+    auto variant_elem = build_variant_schema(
+      "data", field_repetition_type::required);
+    auto schema = make_root(std::move(variant_elem));
+
+    auto row = encode_variant_for_writer(copy_variant(val));
+    auto file = write_single_row(std::move(schema), std::move(row));
+
+    auto records = read_file_as_records(std::move(file)).get();
+    ASSERT_EQ(records.size(), 1);
+
+    // Top-level record has one member: the variant group.
+    const auto& top = records[0];
+    ASSERT_EQ(top.size(), 1);
+    const auto* variant_group = std::get_if<group_value>(&top[0].field);
+    ASSERT_NE(variant_group, nullptr);
+    ASSERT_EQ(variant_group->size(), 2);
+
+    // Extract metadata and value byte arrays.
+    const auto* meta_ba = std::get_if<byte_array_value>(
+      &(*variant_group)[0].field);
+    const auto* val_ba = std::get_if<byte_array_value>(
+      &(*variant_group)[1].field);
+    ASSERT_NE(meta_ba, nullptr);
+    ASSERT_NE(val_ba, nullptr);
+
+    // Decode and compare to original.
+    auto decoded = decode_variant(meta_ba->val, val_ba->val);
+    EXPECT_EQ(decoded, val);
+}
+
+TEST(VariantIntegration, ShreddedWriteRead) {
+    auto json = iobuf::from(R"({"name":"alice","age":30,"extra":true})");
+    auto val = parse_json_to_variant(std::move(json)).get();
+
+    variant_shredding_schema shredding;
+    variant_shredding_field age_field;
+    age_field.field_path.push_back("age");
+    age_field.type = i32_type{};
+    shredding.fields.push_back(std::move(age_field));
+
+    auto variant_elem = build_variant_schema(
+      "data", field_repetition_type::required, shredding);
+    auto schema = make_root(std::move(variant_elem));
+
+    auto row = encode_variant_for_writer(copy_variant(val), shredding);
+    auto file = write_single_row(std::move(schema), std::move(row));
+
+    auto records = read_file_as_records(std::move(file)).get();
+    ASSERT_EQ(records.size(), 1);
+
+    const auto& top = records[0];
+    ASSERT_EQ(top.size(), 1);
+    const auto* variant_group = std::get_if<group_value>(&top[0].field);
+    ASSERT_NE(variant_group, nullptr);
+    // 3 children: metadata, value, typed_value
+    ASSERT_EQ(variant_group->size(), 3);
+
+    // typed_value group contains the shredded age field.
+    const auto* typed_value_group = std::get_if<group_value>(
+      &(*variant_group)[2].field);
+    ASSERT_NE(typed_value_group, nullptr);
+    ASSERT_EQ(typed_value_group->size(), 1);
+
+    const auto* age_val = std::get_if<int32_value>(
+      &(*typed_value_group)[0].field);
+    ASSERT_NE(age_val, nullptr);
+    EXPECT_EQ(age_val->val, 30);
+
+    // The residual should still be decodable and contain name + extra.
+    const auto* meta_ba = std::get_if<byte_array_value>(
+      &(*variant_group)[0].field);
+    ASSERT_NE(meta_ba, nullptr);
+
+    // Value could be byte_array (non-trivial residual) or null (trivial).
+    // With name + extra remaining, it should be non-trivial.
+    const auto* val_ba = std::get_if<byte_array_value>(
+      &(*variant_group)[1].field);
+    ASSERT_NE(val_ba, nullptr);
+
+    auto residual = decode_variant(meta_ba->val, val_ba->val);
+    // The residual should be an object without "age".
+    const auto* obj_ptr = std::get_if<std::unique_ptr<variant_object>>(
+      &residual);
+    ASSERT_NE(obj_ptr, nullptr);
+    ASSERT_NE(*obj_ptr, nullptr);
+    for (const auto& [key, _] : (*obj_ptr)->fields) {
+        EXPECT_NE(key, "age");
+    }
+}
+
+TEST(VariantIntegration, ShreddedNestedPath) {
+    auto json = iobuf::from(R"({"event":{"type":"click","ts":42},"id":1})");
+    auto val = parse_json_to_variant(std::move(json)).get();
+
+    variant_shredding_schema shredding;
+    variant_shredding_field type_field;
+    type_field.field_path.push_back("event");
+    type_field.field_path.push_back("type");
+    type_field.type = byte_array_type{};
+    shredding.fields.push_back(std::move(type_field));
+
+    auto variant_elem = build_variant_schema(
+      "data", field_repetition_type::required, shredding);
+
+    // Verify schema structure: typed_value -> event (group) -> type (leaf).
+    ASSERT_EQ(variant_elem.children.size(), 3);
+    const auto& tv = variant_elem.children[2];
+    EXPECT_EQ(tv.name(), "typed_value");
+    ASSERT_EQ(tv.children.size(), 1);
+    EXPECT_EQ(tv.children[0].name(), "event");
+    ASSERT_EQ(tv.children[0].children.size(), 1);
+    EXPECT_EQ(tv.children[0].children[0].name(), "type");
+    EXPECT_TRUE(
+      std::holds_alternative<string_type>(
+        tv.children[0].children[0].logical_type));
+
+    auto schema = make_root(std::move(variant_elem));
+    auto row = encode_variant_for_writer(copy_variant(val), shredding);
+    auto file = write_single_row(std::move(schema), std::move(row));
+
+    auto records = read_file_as_records(std::move(file)).get();
+    ASSERT_EQ(records.size(), 1);
+
+    const auto& top = records[0];
+    ASSERT_EQ(top.size(), 1);
+    const auto* vg = std::get_if<group_value>(&top[0].field);
+    ASSERT_NE(vg, nullptr);
+    ASSERT_EQ(vg->size(), 3);
+
+    // typed_value -> event group -> type leaf
+    const auto* tv_group = std::get_if<group_value>(&(*vg)[2].field);
+    ASSERT_NE(tv_group, nullptr);
+    ASSERT_EQ(tv_group->size(), 1);
+    const auto* event_group = std::get_if<group_value>(&(*tv_group)[0].field);
+    ASSERT_NE(event_group, nullptr);
+    ASSERT_EQ(event_group->size(), 1);
+    const auto* type_val = std::get_if<byte_array_value>(
+      &(*event_group)[0].field);
+    ASSERT_NE(type_val, nullptr);
+
+    iobuf expected_val = iobuf::from("click");
+    EXPECT_EQ(type_val->val, expected_val);
+}
+
+TEST(VariantIntegration, UnshredddedDecodeFromReader) {
+    auto json = iobuf::from(R"({"name":"alice","age":30})");
+    auto original = parse_json_to_variant(std::move(json)).get();
+
+    auto variant_elem = build_variant_schema(
+      "data", field_repetition_type::required);
+    auto schema = make_root(std::move(variant_elem));
+
+    auto row = encode_variant_for_writer(copy_variant(original));
+    auto file = write_single_row(std::move(schema), std::move(row));
+
+    auto records = read_file_as_records(std::move(file)).get();
+    ASSERT_EQ(records.size(), 1);
+    const auto& top = records[0];
+    ASSERT_EQ(top.size(), 1);
+    const auto* variant_group = std::get_if<group_value>(&top[0].field);
+    ASSERT_NE(variant_group, nullptr);
+
+    auto decoded = decode_variant_from_reader(*variant_group);
+    EXPECT_EQ(decoded, original);
+}
+
+TEST(VariantIntegration, ShreddedRoundTrip) {
+    auto json = iobuf::from(R"({"name":"alice","age":30,"score":95.5})");
+    auto original = parse_json_to_variant(std::move(json)).get();
+
+    variant_shredding_schema shredding;
+    variant_shredding_field age_field;
+    age_field.field_path.push_back("age");
+    age_field.type = i32_type{};
+    shredding.fields.push_back(std::move(age_field));
+
+    auto variant_elem = build_variant_schema(
+      "data", field_repetition_type::required, shredding);
+    auto schema = make_root(std::move(variant_elem));
+
+    auto row = encode_variant_for_writer(copy_variant(original), shredding);
+    auto file = write_single_row(std::move(schema), std::move(row));
+
+    auto records = read_file_as_records(std::move(file)).get();
+    ASSERT_EQ(records.size(), 1);
+    const auto& top = records[0];
+    ASSERT_EQ(top.size(), 1);
+    const auto* variant_group = std::get_if<group_value>(&top[0].field);
+    ASSERT_NE(variant_group, nullptr);
+
+    auto decoded = decode_variant_from_reader(*variant_group, shredding);
+    EXPECT_EQ(decoded, original);
+}
+
+TEST(VariantIntegration, ShreddedNestedPathRoundTrip) {
+    auto json = iobuf::from(R"({"event":{"type":"click","ts":42},"id":1})");
+    auto original = parse_json_to_variant(std::move(json)).get();
+
+    variant_shredding_schema shredding;
+    variant_shredding_field type_field;
+    type_field.field_path.push_back("event");
+    type_field.field_path.push_back("type");
+    type_field.type = byte_array_type{};
+    shredding.fields.push_back(std::move(type_field));
+
+    auto variant_elem = build_variant_schema(
+      "data", field_repetition_type::required, shredding);
+    auto schema = make_root(std::move(variant_elem));
+
+    auto row = encode_variant_for_writer(copy_variant(original), shredding);
+    auto file = write_single_row(std::move(schema), std::move(row));
+
+    auto records = read_file_as_records(std::move(file)).get();
+    ASSERT_EQ(records.size(), 1);
+    const auto& top = records[0];
+    ASSERT_EQ(top.size(), 1);
+    const auto* variant_group = std::get_if<group_value>(&top[0].field);
+    ASSERT_NE(variant_group, nullptr);
+
+    auto decoded = decode_variant_from_reader(*variant_group, shredding);
+    EXPECT_EQ(decoded, original);
+}
+
+TEST(VariantIntegration, ShreddedTrivialResidualRoundTrip) {
+    auto json = iobuf::from(R"({"age":30})");
+    auto original = parse_json_to_variant(std::move(json)).get();
+
+    variant_shredding_schema shredding;
+    variant_shredding_field age_field;
+    age_field.field_path.push_back("age");
+    age_field.type = i32_type{};
+    shredding.fields.push_back(std::move(age_field));
+
+    auto variant_elem = build_variant_schema(
+      "data", field_repetition_type::required, shredding);
+    auto schema = make_root(std::move(variant_elem));
+
+    auto row = encode_variant_for_writer(copy_variant(original), shredding);
+    auto file = write_single_row(std::move(schema), std::move(row));
+
+    auto records = read_file_as_records(std::move(file)).get();
+    ASSERT_EQ(records.size(), 1);
+    const auto& top = records[0];
+    ASSERT_EQ(top.size(), 1);
+    const auto* variant_group = std::get_if<group_value>(&top[0].field);
+    ASSERT_NE(variant_group, nullptr);
+
+    auto decoded = decode_variant_from_reader(*variant_group, shredding);
+    EXPECT_EQ(decoded, original);
+}
+
+// NOLINTEND(*magic-number*)
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/tests/variant_json_test.cc
+++ b/src/v/serde/parquet/tests/variant_json_test.cc
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "serde/parquet/variant_encoding.h"
+#include "serde/parquet/variant_json.h"
+#include "serde/parquet/variant_value.h"
+
+#include <gtest/gtest.h>
+
+using namespace serde::parquet;
+
+TEST(VariantJson, Null) {
+    auto v = parse_json_to_variant(iobuf::from("null")).get();
+    EXPECT_TRUE(std::holds_alternative<null_value>(v));
+}
+
+TEST(VariantJson, BoolTrue) {
+    auto v = parse_json_to_variant(iobuf::from("true")).get();
+    EXPECT_EQ(std::get<boolean_value>(v), (boolean_value{true}));
+}
+
+TEST(VariantJson, BoolFalse) {
+    auto v = parse_json_to_variant(iobuf::from("false")).get();
+    EXPECT_EQ(std::get<boolean_value>(v), (boolean_value{false}));
+}
+
+TEST(VariantJson, Integer) {
+    auto v = parse_json_to_variant(iobuf::from("42")).get();
+    EXPECT_EQ(std::get<int32_value>(v), (int32_value{42}));
+}
+
+TEST(VariantJson, NegativeInteger) {
+    auto v = parse_json_to_variant(iobuf::from("-100")).get();
+    EXPECT_EQ(std::get<int32_value>(v), (int32_value{-100}));
+}
+
+TEST(VariantJson, LargeInteger) {
+    auto v = parse_json_to_variant(iobuf::from("3000000000")).get();
+    EXPECT_EQ(std::get<int64_value>(v), (int64_value{3000000000}));
+}
+
+TEST(VariantJson, Double) {
+    auto v = parse_json_to_variant(iobuf::from("3.14")).get();
+    EXPECT_EQ(std::get<float64_value>(v).val, 3.14);
+}
+
+TEST(VariantJson, String) {
+    auto v = parse_json_to_variant(iobuf::from("\"hello\"")).get();
+    EXPECT_EQ(std::get<variant_string_value>(v).val, "hello");
+}
+
+TEST(VariantJson, EmptyString) {
+    auto v = parse_json_to_variant(iobuf::from("\"\"")).get();
+    EXPECT_EQ(std::get<variant_string_value>(v).val, "");
+}
+
+TEST(VariantJson, Object) {
+    auto v = parse_json_to_variant(iobuf::from(R"({"b":2,"a":1})")).get();
+    auto* obj = std::get_if<std::unique_ptr<variant_object>>(&v);
+    ASSERT_NE(obj, nullptr);
+    ASSERT_EQ((*obj)->fields.size(), 2);
+    EXPECT_EQ((*obj)->fields[0].first, "a");
+    EXPECT_EQ((*obj)->fields[1].first, "b");
+}
+
+TEST(VariantJson, EmptyObject) {
+    auto v = parse_json_to_variant(iobuf::from("{}")).get();
+    auto* obj = std::get_if<std::unique_ptr<variant_object>>(&v);
+    ASSERT_NE(obj, nullptr);
+    EXPECT_EQ((*obj)->fields.size(), 0);
+}
+
+TEST(VariantJson, Array) {
+    auto v = parse_json_to_variant(iobuf::from(R"([1,"two",null])")).get();
+    auto* arr = std::get_if<std::unique_ptr<variant_array>>(&v);
+    ASSERT_NE(arr, nullptr);
+    ASSERT_EQ((*arr)->elements.size(), 3);
+    EXPECT_TRUE(std::holds_alternative<int32_value>((*arr)->elements[0]));
+    EXPECT_TRUE(
+      std::holds_alternative<variant_string_value>((*arr)->elements[1]));
+    EXPECT_TRUE(std::holds_alternative<null_value>((*arr)->elements[2]));
+}
+
+TEST(VariantJson, EmptyArray) {
+    auto v = parse_json_to_variant(iobuf::from("[]")).get();
+    auto* arr = std::get_if<std::unique_ptr<variant_array>>(&v);
+    ASSERT_NE(arr, nullptr);
+    EXPECT_EQ((*arr)->elements.size(), 0);
+}
+
+TEST(VariantJson, Nested) {
+    auto v = parse_json_to_variant(iobuf::from(R"({"a":{"b":[1,2,3]}})")).get();
+    auto* obj = std::get_if<std::unique_ptr<variant_object>>(&v);
+    ASSERT_NE(obj, nullptr);
+    ASSERT_EQ((*obj)->fields.size(), 1);
+    EXPECT_EQ((*obj)->fields[0].first, "a");
+    auto* inner = std::get_if<std::unique_ptr<variant_object>>(
+      &(*obj)->fields[0].second);
+    ASSERT_NE(inner, nullptr);
+    ASSERT_EQ((*inner)->fields.size(), 1);
+    auto* arr = std::get_if<std::unique_ptr<variant_array>>(
+      &(*inner)->fields[0].second);
+    ASSERT_NE(arr, nullptr);
+    EXPECT_EQ((*arr)->elements.size(), 3);
+}
+
+TEST(VariantJson, RoundTripThroughEncoding) {
+    auto v = parse_json_to_variant(
+               iobuf::from(R"({"name":"alice","age":30,"scores":[95,87]})"))
+               .get();
+    auto encoded = encode_variant(v);
+    auto decoded = decode_variant(encoded.metadata, encoded.value);
+    EXPECT_EQ(v, decoded);
+}

--- a/src/v/serde/parquet/tests/variant_shredder_test.cc
+++ b/src/v/serde/parquet/tests/variant_shredder_test.cc
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "bytes/iobuf.h"
+#include "serde/parquet/variant_shredder.h"
+#include "serde/parquet/variant_value.h"
+
+#include <gtest/gtest.h>
+
+using namespace serde::parquet;
+
+namespace {
+
+variant_value
+make_object(chunked_vector<std::pair<ss::sstring, variant_value>> fields) {
+    auto obj = std::make_unique<variant_object>();
+    obj->fields = std::move(fields);
+    return obj;
+}
+
+chunked_vector<ss::sstring> path(std::initializer_list<ss::sstring> parts) {
+    chunked_vector<ss::sstring> result;
+    for (auto& p : parts) {
+        result.push_back(p);
+    }
+    return result;
+}
+
+} // namespace
+
+TEST(VariantShredder, TopLevelField) {
+    // {"a":1, "b":2} with schema [{path:["a"], type:i32}]
+    chunked_vector<std::pair<ss::sstring, variant_value>> fields;
+    fields.emplace_back("a", int32_value{1});
+    fields.emplace_back("b", int32_value{2});
+    auto val = make_object(std::move(fields));
+
+    variant_shredding_schema schema;
+    variant_shredding_field f;
+    f.field_path = path({"a"});
+    f.type = i32_type{};
+    schema.fields.push_back(std::move(f));
+
+    auto result = shred_variant(std::move(val), schema);
+
+    ASSERT_EQ(result.typed_values.size(), 1);
+    EXPECT_EQ(result.typed_values[0], value{int32_value{1}});
+
+    // Residual should be {"b":2}
+    auto* obj = std::get_if<std::unique_ptr<variant_object>>(&result.residual);
+    ASSERT_NE(obj, nullptr);
+    ASSERT_EQ((*obj)->fields.size(), 1);
+    EXPECT_EQ((*obj)->fields[0].first, "b");
+    EXPECT_EQ((*obj)->fields[0].second, variant_value{int32_value{2}});
+}
+
+TEST(VariantShredder, NestedField) {
+    // {"x":{"y":1}} with schema [{path:["x","y"], type:i32}]
+    chunked_vector<std::pair<ss::sstring, variant_value>> inner_fields;
+    inner_fields.emplace_back("y", int32_value{1});
+    auto inner = make_object(std::move(inner_fields));
+
+    chunked_vector<std::pair<ss::sstring, variant_value>> outer_fields;
+    outer_fields.emplace_back("x", std::move(inner));
+    auto val = make_object(std::move(outer_fields));
+
+    variant_shredding_schema schema;
+    variant_shredding_field f;
+    f.field_path = path({"x", "y"});
+    f.type = i32_type{};
+    schema.fields.push_back(std::move(f));
+
+    auto result = shred_variant(std::move(val), schema);
+
+    ASSERT_EQ(result.typed_values.size(), 1);
+    EXPECT_EQ(result.typed_values[0], value{int32_value{1}});
+
+    // Residual should be {"x":{}}
+    auto* obj = std::get_if<std::unique_ptr<variant_object>>(&result.residual);
+    ASSERT_NE(obj, nullptr);
+    ASSERT_EQ((*obj)->fields.size(), 1);
+    EXPECT_EQ((*obj)->fields[0].first, "x");
+    auto* inner_obj = std::get_if<std::unique_ptr<variant_object>>(
+      &(*obj)->fields[0].second);
+    ASSERT_NE(inner_obj, nullptr);
+    EXPECT_TRUE((*inner_obj)->fields.empty());
+}
+
+TEST(VariantShredder, AbsentField) {
+    // {"a":1} with schema [{path:["b"], type:i32}]
+    chunked_vector<std::pair<ss::sstring, variant_value>> fields;
+    fields.emplace_back("a", int32_value{1});
+    auto val = make_object(std::move(fields));
+
+    variant_shredding_schema schema;
+    variant_shredding_field f;
+    f.field_path = path({"b"});
+    f.type = i32_type{};
+    schema.fields.push_back(std::move(f));
+
+    auto result = shred_variant(std::move(val), schema);
+
+    ASSERT_EQ(result.typed_values.size(), 1);
+    EXPECT_EQ(result.typed_values[0], value{null_value{}});
+
+    // Residual unchanged: {"a":1}
+    auto* obj = std::get_if<std::unique_ptr<variant_object>>(&result.residual);
+    ASSERT_NE(obj, nullptr);
+    ASSERT_EQ((*obj)->fields.size(), 1);
+    EXPECT_EQ((*obj)->fields[0].first, "a");
+}
+
+TEST(VariantShredder, TypeMismatch) {
+    // {"a":"string"} with schema [{path:["a"], type:i32}]
+    chunked_vector<std::pair<ss::sstring, variant_value>> fields;
+    fields.emplace_back("a", variant_string_value{"string"});
+    auto val = make_object(std::move(fields));
+
+    variant_shredding_schema schema;
+    variant_shredding_field f;
+    f.field_path = path({"a"});
+    f.type = i32_type{};
+    schema.fields.push_back(std::move(f));
+
+    auto result = shred_variant(std::move(val), schema);
+
+    ASSERT_EQ(result.typed_values.size(), 1);
+    EXPECT_EQ(result.typed_values[0], value{null_value{}});
+
+    // Residual still has {"a":"string"}
+    auto* obj = std::get_if<std::unique_ptr<variant_object>>(&result.residual);
+    ASSERT_NE(obj, nullptr);
+    ASSERT_EQ((*obj)->fields.size(), 1);
+    EXPECT_EQ((*obj)->fields[0].first, "a");
+    EXPECT_EQ(
+      (*obj)->fields[0].second, variant_value{variant_string_value{"string"}});
+}
+
+TEST(VariantShredder, EmptySchema) {
+    // {"a":1} with empty schema
+    chunked_vector<std::pair<ss::sstring, variant_value>> fields;
+    fields.emplace_back("a", int32_value{1});
+    auto val = make_object(std::move(fields));
+
+    variant_shredding_schema schema;
+
+    auto result = shred_variant(std::move(val), schema);
+
+    EXPECT_TRUE(result.typed_values.empty());
+
+    auto* obj = std::get_if<std::unique_ptr<variant_object>>(&result.residual);
+    ASSERT_NE(obj, nullptr);
+    ASSERT_EQ((*obj)->fields.size(), 1);
+    EXPECT_EQ((*obj)->fields[0].first, "a");
+}
+
+TEST(VariantShredder, MultipleFields) {
+    // {"a":1, "b":"hello", "c":3.14} with schema
+    //   [{path:["a"],i32}, {path:["b"],byte_array}]
+    chunked_vector<std::pair<ss::sstring, variant_value>> fields;
+    fields.emplace_back("a", int32_value{1});
+    fields.emplace_back("b", variant_string_value{"hello"});
+    fields.emplace_back("c", float64_value{3.14});
+    auto val = make_object(std::move(fields));
+
+    variant_shredding_schema schema;
+    {
+        variant_shredding_field f;
+        f.field_path = path({"a"});
+        f.type = i32_type{};
+        schema.fields.push_back(std::move(f));
+    }
+    {
+        variant_shredding_field f;
+        f.field_path = path({"b"});
+        f.type = byte_array_type{};
+        schema.fields.push_back(std::move(f));
+    }
+
+    auto result = shred_variant(std::move(val), schema);
+
+    ASSERT_EQ(result.typed_values.size(), 2);
+    EXPECT_EQ(result.typed_values[0], value{int32_value{1}});
+    EXPECT_EQ(
+      result.typed_values[1], value{byte_array_value{iobuf::from("hello")}});
+
+    // Residual should be {"c":3.14}
+    auto* obj = std::get_if<std::unique_ptr<variant_object>>(&result.residual);
+    ASSERT_NE(obj, nullptr);
+    ASSERT_EQ((*obj)->fields.size(), 1);
+    EXPECT_EQ((*obj)->fields[0].first, "c");
+}
+
+TEST(VariantShredder, StringAsBytes) {
+    // {"s":"text"} with schema [{path:["s"], type:byte_array}]
+    chunked_vector<std::pair<ss::sstring, variant_value>> fields;
+    fields.emplace_back("s", variant_string_value{"text"});
+    auto val = make_object(std::move(fields));
+
+    variant_shredding_schema schema;
+    variant_shredding_field f;
+    f.field_path = path({"s"});
+    f.type = byte_array_type{};
+    schema.fields.push_back(std::move(f));
+
+    auto result = shred_variant(std::move(val), schema);
+
+    ASSERT_EQ(result.typed_values.size(), 1);
+    EXPECT_EQ(
+      result.typed_values[0], value{byte_array_value{iobuf::from("text")}});
+
+    // Residual should be empty object
+    auto* obj = std::get_if<std::unique_ptr<variant_object>>(&result.residual);
+    ASSERT_NE(obj, nullptr);
+    EXPECT_TRUE((*obj)->fields.empty());
+}
+
+TEST(VariantShredder, NonObjectInput) {
+    // int32_value{42} with schema [{path:["a"], type:i32}]
+    variant_value val = int32_value{42};
+
+    variant_shredding_schema schema;
+    variant_shredding_field f;
+    f.field_path = path({"a"});
+    f.type = i32_type{};
+    schema.fields.push_back(std::move(f));
+
+    auto result = shred_variant(std::move(val), schema);
+
+    ASSERT_EQ(result.typed_values.size(), 1);
+    EXPECT_EQ(result.typed_values[0], value{null_value{}});
+
+    // Residual is the original primitive
+    EXPECT_EQ(result.residual, variant_value{int32_value{42}});
+}

--- a/src/v/serde/parquet/tests/variant_value_test.cc
+++ b/src/v/serde/parquet/tests/variant_value_test.cc
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "bytes/iobuf.h"
+#include "serde/parquet/variant_value.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+using namespace serde::parquet;
+
+TEST(VariantValue, Primitives) {
+    variant_value v_null = null_value{};
+    EXPECT_TRUE(std::holds_alternative<null_value>(v_null));
+
+    variant_value v_bool = boolean_value{.val = true};
+    EXPECT_TRUE(std::holds_alternative<boolean_value>(v_bool));
+
+    variant_value v_i32 = int32_value{.val = 42};
+    EXPECT_EQ(std::get<int32_value>(v_i32).val, 42);
+
+    variant_value v_i64 = int64_value{.val = 1234567890LL};
+    EXPECT_EQ(std::get<int64_value>(v_i64).val, 1234567890LL);
+
+    variant_value v_f32 = float32_value{.val = 3.14f};
+    EXPECT_FLOAT_EQ(std::get<float32_value>(v_f32).val, 3.14f);
+
+    variant_value v_f64 = float64_value{.val = 2.718281828};
+    EXPECT_DOUBLE_EQ(std::get<float64_value>(v_f64).val, 2.718281828);
+
+    variant_value v_str = variant_string_value{.val = "hello"};
+    EXPECT_EQ(std::get<variant_string_value>(v_str).val, "hello");
+
+    iobuf buf;
+    buf.append("bytes", 5);
+    variant_value v_bytes = byte_array_value{.val = std::move(buf)};
+    EXPECT_EQ(std::get<byte_array_value>(v_bytes).val.size_bytes(), 5);
+}
+
+TEST(VariantValue, Object) {
+    auto obj = std::make_unique<variant_object>();
+    obj->fields.emplace_back("name", variant_string_value{.val = "alice"});
+    obj->fields.emplace_back("age", int32_value{.val = 30});
+    obj->fields.emplace_back("active", boolean_value{.val = true});
+
+    variant_value v = std::move(obj);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<variant_object>>(v));
+    const auto& o = *std::get<std::unique_ptr<variant_object>>(v);
+    EXPECT_EQ(o.fields.size(), 3);
+    EXPECT_EQ(o.fields[0].first, "name");
+    EXPECT_EQ(o.fields[1].first, "age");
+}
+
+TEST(VariantValue, Array) {
+    auto arr = std::make_unique<variant_array>();
+    arr->elements.emplace_back(int32_value{.val = 1});
+    arr->elements.emplace_back(variant_string_value{.val = "two"});
+    arr->elements.emplace_back(boolean_value{.val = false});
+
+    variant_value v = std::move(arr);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<variant_array>>(v));
+    const auto& a = *std::get<std::unique_ptr<variant_array>>(v);
+    EXPECT_EQ(a.elements.size(), 3);
+}
+
+TEST(VariantValue, NestedObjectArrayObject) {
+    // { "items": [ { "id": 1 }, { "id": 2 } ] }
+    auto inner1 = std::make_unique<variant_object>();
+    inner1->fields.emplace_back("id", int32_value{.val = 1});
+
+    auto inner2 = std::make_unique<variant_object>();
+    inner2->fields.emplace_back("id", int32_value{.val = 2});
+
+    auto arr = std::make_unique<variant_array>();
+    arr->elements.emplace_back(std::move(inner1));
+    arr->elements.emplace_back(std::move(inner2));
+
+    auto outer = std::make_unique<variant_object>();
+    outer->fields.emplace_back("items", std::move(arr));
+
+    variant_value v = std::move(outer);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<variant_object>>(v));
+
+    const auto& root = *std::get<std::unique_ptr<variant_object>>(v);
+    ASSERT_EQ(root.fields.size(), 1);
+    EXPECT_EQ(root.fields[0].first, "items");
+
+    const auto& items_arr = *std::get<std::unique_ptr<variant_array>>(
+      root.fields[0].second);
+    ASSERT_EQ(items_arr.elements.size(), 2);
+
+    const auto& item0 = *std::get<std::unique_ptr<variant_object>>(
+      items_arr.elements[0]);
+    EXPECT_EQ(std::get<int32_value>(item0.fields[0].second).val, 1);
+}
+
+TEST(VariantValue, EqualitySameStructure) {
+    auto make_obj = []() {
+        auto obj = std::make_unique<variant_object>();
+        obj->fields.emplace_back("x", int32_value{.val = 10});
+        obj->fields.emplace_back("y", variant_string_value{.val = "hello"});
+        return variant_value{std::move(obj)};
+    };
+    auto a = make_obj();
+    auto b = make_obj();
+    EXPECT_TRUE(a == b);
+}
+
+TEST(VariantValue, EqualityDifferentValues) {
+    variant_value a = int32_value{.val = 1};
+    variant_value b = int32_value{.val = 2};
+    EXPECT_FALSE(a == b);
+}
+
+TEST(VariantValue, EqualityDifferentTypes) {
+    variant_value a = int32_value{.val = 1};
+    variant_value b = int64_value{.val = 1};
+    EXPECT_FALSE(a == b);
+}
+
+TEST(VariantValue, EqualityNestedArrays) {
+    auto make_arr = []() {
+        auto arr = std::make_unique<variant_array>();
+        arr->elements.emplace_back(int32_value{.val = 1});
+        arr->elements.emplace_back(int32_value{.val = 2});
+        return variant_value{std::move(arr)};
+    };
+    EXPECT_TRUE(make_arr() == make_arr());
+
+    auto arr_different = std::make_unique<variant_array>();
+    arr_different->elements.emplace_back(int32_value{.val = 1});
+    arr_different->elements.emplace_back(int32_value{.val = 99});
+    variant_value c = std::move(arr_different);
+
+    EXPECT_FALSE(make_arr() == c);
+}
+
+TEST(VariantValue, CopyPrimitive) {
+    variant_value orig = int32_value{.val = 42};
+    auto copied = copy_variant(orig);
+    EXPECT_TRUE(orig == copied);
+}
+
+TEST(VariantValue, CopyByteArray) {
+    iobuf buf;
+    buf.append("data", 4);
+    variant_value orig = byte_array_value{.val = std::move(buf)};
+    auto copied = copy_variant(orig);
+    EXPECT_TRUE(orig == copied);
+}
+
+TEST(VariantValue, CopyObjectIndependent) {
+    auto obj = std::make_unique<variant_object>();
+    obj->fields.emplace_back("key", int32_value{.val = 100});
+    variant_value orig = std::move(obj);
+
+    auto copied = copy_variant(orig);
+    EXPECT_TRUE(orig == copied);
+
+    // Mutate the copy and verify independence.
+    auto& copied_obj = *std::get<std::unique_ptr<variant_object>>(copied);
+    copied_obj.fields[0].second = int32_value{.val = 999};
+    EXPECT_FALSE(orig == copied);
+}
+
+TEST(VariantValue, CopyNestedArray) {
+    auto inner = std::make_unique<variant_object>();
+    inner->fields.emplace_back("v", boolean_value{.val = true});
+
+    auto arr = std::make_unique<variant_array>();
+    arr->elements.emplace_back(std::move(inner));
+    arr->elements.emplace_back(int64_value{.val = 7});
+
+    variant_value orig = std::move(arr);
+    auto copied = copy_variant(orig);
+    EXPECT_TRUE(orig == copied);
+}
+
+TEST(VariantValue, SortObject) {
+    auto obj = std::make_unique<variant_object>();
+    obj->fields.emplace_back("zebra", int32_value{.val = 3});
+    obj->fields.emplace_back("apple", int32_value{.val = 1});
+    obj->fields.emplace_back("mango", int32_value{.val = 2});
+
+    sort_variant_object(*obj);
+
+    ASSERT_EQ(obj->fields.size(), 3);
+    EXPECT_EQ(obj->fields[0].first, "apple");
+    EXPECT_EQ(obj->fields[1].first, "mango");
+    EXPECT_EQ(obj->fields[2].first, "zebra");
+    EXPECT_EQ(std::get<int32_value>(obj->fields[0].second).val, 1);
+    EXPECT_EQ(std::get<int32_value>(obj->fields[1].second).val, 2);
+    EXPECT_EQ(std::get<int32_value>(obj->fields[2].second).val, 3);
+}
+
+TEST(VariantValue, SortEmptyObject) {
+    variant_object obj;
+    sort_variant_object(obj);
+    EXPECT_TRUE(obj.fields.empty());
+}

--- a/src/v/serde/parquet/variant_encoding.cc
+++ b/src/v/serde/parquet/variant_encoding.cc
@@ -1,0 +1,518 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "serde/parquet/variant_encoding.h"
+
+#include "base/vassert.h"
+#include "bytes/iobuf_parser.h"
+#include "container/chunked_vector.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <algorithm>
+#include <bit>
+#include <cstdint>
+#include <cstring>
+#include <set>
+#include <utility>
+
+namespace serde::parquet {
+
+namespace {
+
+// basic_type values for the value header byte
+constexpr uint8_t basic_type_primitive = 0;
+constexpr uint8_t basic_type_short_string = 1;
+constexpr uint8_t basic_type_object = 2;
+constexpr uint8_t basic_type_array = 3;
+
+// primitive type_info values
+constexpr uint8_t prim_null = 0;
+constexpr uint8_t prim_true = 1;
+constexpr uint8_t prim_false = 2;
+constexpr uint8_t prim_int32 = 5;
+constexpr uint8_t prim_int64 = 6;
+constexpr uint8_t prim_double = 7;
+constexpr uint8_t prim_float = 14;
+constexpr uint8_t prim_binary = 15;
+constexpr uint8_t prim_string = 16;
+
+uint8_t make_value_header(uint8_t basic_type, uint8_t type_info) {
+    return static_cast<uint8_t>(
+      (basic_type & 0x03) | ((type_info & 0x3F) << 2));
+}
+
+/// Return the minimum number of bytes (1-4) needed to represent val.
+uint8_t min_bytes_for(uint32_t val) {
+    if (val <= 0xFF) {
+        return 1;
+    }
+    if (val <= 0xFFFF) {
+        return 2;
+    }
+    if (val <= 0xFFFFFF) {
+        return 3;
+    }
+    return 4;
+}
+
+void append_le_uint(iobuf& buf, uint32_t val, uint8_t width) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    uint8_t le[4];
+    std::memcpy(le, &val, 4);
+    buf.append(le, width);
+}
+
+uint32_t read_le_uint(iobuf_const_parser& p, uint8_t width) {
+    uint8_t raw[4] = {};
+    p.consume_to(width, raw);
+    uint32_t val = 0;
+    std::memcpy(&val, raw, 4);
+    return val;
+}
+
+// -- Dictionary builder: collect all object field names --
+
+void collect_field_names(
+  const variant_value& val, std::set<ss::sstring>& names) {
+    std::visit(
+      [&names](const auto& v) {
+          using T = std::decay_t<decltype(v)>;
+          if constexpr (std::is_same_v<T, std::unique_ptr<variant_object>>) {
+              for (const auto& [key, field_val] : v->fields) {
+                  names.insert(key);
+                  collect_field_names(field_val, names);
+              }
+          } else if constexpr (
+            std::is_same_v<T, std::unique_ptr<variant_array>>) {
+              for (const auto& elem : v->elements) {
+                  collect_field_names(elem, names);
+              }
+          }
+      },
+      val);
+}
+
+// -- Metadata encoder --
+
+iobuf encode_metadata(const chunked_vector<ss::sstring>& dictionary) {
+    // Compute total string data size and max offset for offset_size.
+    uint32_t total_string_bytes = 0;
+    for (const auto& s : dictionary) {
+        total_string_bytes += static_cast<uint32_t>(s.size());
+    }
+
+    uint8_t offset_size = min_bytes_for(
+      std::max(total_string_bytes, static_cast<uint32_t>(dictionary.size())));
+
+    // Header byte: version=1, sorted_strings=1, offset_size_minus_one
+    uint8_t header = 1          // version (bits 0-3)
+                     | (1 << 4) // sorted_strings (bit 4)
+                     | (static_cast<uint8_t>((offset_size - 1) & 0x03) << 5);
+
+    iobuf meta;
+    meta.append(&header, 1);
+
+    // Dictionary size
+    append_le_uint(meta, static_cast<uint32_t>(dictionary.size()), offset_size);
+
+    // Offset array: dictionary_size + 1 entries
+    uint32_t offset = 0;
+    for (size_t i = 0; i <= dictionary.size(); ++i) {
+        append_le_uint(meta, offset, offset_size);
+        if (i < dictionary.size()) {
+            offset += static_cast<uint32_t>(dictionary[i].size());
+        }
+    }
+
+    // String data
+    for (const auto& s : dictionary) {
+        meta.append(s.data(), s.size());
+    }
+
+    return meta;
+}
+
+// -- Value encoder --
+
+void encode_value(
+  const variant_value& val,
+  const chunked_vector<ss::sstring>& dictionary,
+  iobuf& out);
+
+void encode_object(
+  const variant_object& obj,
+  const chunked_vector<ss::sstring>& dictionary,
+  iobuf& out) {
+    auto num_fields = static_cast<uint32_t>(obj.fields.size());
+
+    // Find field IDs (indices into dictionary)
+    chunked_vector<uint32_t> field_ids;
+    field_ids.reserve(num_fields);
+    for (const auto& [key, _] : obj.fields) {
+        auto it = std::lower_bound(dictionary.begin(), dictionary.end(), key);
+        vassert(
+          it != dictionary.end() && *it == key,
+          "field name not found in dictionary: {}",
+          key);
+        field_ids.push_back(
+          static_cast<uint32_t>(std::distance(dictionary.begin(), it)));
+    }
+
+    uint32_t max_field_id = 0;
+    for (auto id : field_ids) {
+        max_field_id = std::max(max_field_id, id);
+    }
+
+    // Encode all field values to a temporary buffer to get offsets.
+    chunked_vector<iobuf> field_bufs;
+    field_bufs.reserve(num_fields);
+    for (const auto& [_, field_val] : obj.fields) {
+        iobuf field_buf;
+        encode_value(field_val, dictionary, field_buf);
+        field_bufs.push_back(std::move(field_buf));
+    }
+
+    // Compute field offsets (relative to start of field data).
+    chunked_vector<uint32_t> field_offsets;
+    field_offsets.reserve(num_fields);
+    uint32_t running = 0;
+    for (const auto& fb : field_bufs) {
+        field_offsets.push_back(running);
+        running += static_cast<uint32_t>(fb.size_bytes());
+    }
+
+    uint8_t field_offset_size = num_fields > 0 ? min_bytes_for(running)
+                                               : uint8_t{1};
+    uint8_t field_id_size = num_fields > 0 ? min_bytes_for(max_field_id)
+                                           : uint8_t{1};
+
+    // type_info: bits 0-1 = offset_size-1, bits 2-3 = id_size-1
+    uint8_t type_info = static_cast<uint8_t>(
+      ((field_offset_size - 1) & 0x03) | (((field_id_size - 1) & 0x03) << 2));
+    uint8_t header = make_value_header(basic_type_object, type_info);
+    out.append(&header, 1);
+
+    // num_fields in field_offset_size bytes
+    append_le_uint(out, num_fields, field_offset_size);
+
+    // field_ids array
+    for (auto id : field_ids) {
+        append_le_uint(out, id, field_id_size);
+    }
+
+    // field_offsets array
+    for (auto off : field_offsets) {
+        append_le_uint(out, off, field_offset_size);
+    }
+
+    // field data
+    for (auto& fb : field_bufs) {
+        out.append(std::move(fb));
+    }
+}
+
+void encode_array(
+  const variant_array& arr,
+  const chunked_vector<ss::sstring>& dictionary,
+  iobuf& out) {
+    auto num_elements = static_cast<uint32_t>(arr.elements.size());
+
+    // Encode each element.
+    chunked_vector<iobuf> elem_bufs;
+    elem_bufs.reserve(num_elements);
+    for (const auto& elem : arr.elements) {
+        iobuf elem_buf;
+        encode_value(elem, dictionary, elem_buf);
+        elem_bufs.push_back(std::move(elem_buf));
+    }
+
+    // Compute offsets.
+    chunked_vector<uint32_t> offsets;
+    offsets.reserve(num_elements);
+    uint32_t running = 0;
+    for (const auto& eb : elem_bufs) {
+        offsets.push_back(running);
+        running += static_cast<uint32_t>(eb.size_bytes());
+    }
+
+    uint8_t offset_size = num_elements > 0 ? min_bytes_for(running)
+                                           : uint8_t{1};
+    uint8_t type_info = static_cast<uint8_t>((offset_size - 1) & 0x03);
+    uint8_t header = make_value_header(basic_type_array, type_info);
+    out.append(&header, 1);
+
+    append_le_uint(out, num_elements, offset_size);
+
+    for (auto off : offsets) {
+        append_le_uint(out, off, offset_size);
+    }
+
+    for (auto& eb : elem_bufs) {
+        out.append(std::move(eb));
+    }
+}
+
+void encode_value(
+  const variant_value& val,
+  const chunked_vector<ss::sstring>& dictionary,
+  iobuf& out) {
+    std::visit(
+      [&](const auto& v) {
+          using T = std::decay_t<decltype(v)>;
+          if constexpr (std::is_same_v<T, null_value>) {
+              uint8_t h = make_value_header(basic_type_primitive, prim_null);
+              out.append(&h, 1);
+          } else if constexpr (std::is_same_v<T, boolean_value>) {
+              uint8_t h = make_value_header(
+                basic_type_primitive, v.val ? prim_true : prim_false);
+              out.append(&h, 1);
+          } else if constexpr (std::is_same_v<T, int32_value>) {
+              uint8_t h = make_value_header(basic_type_primitive, prim_int32);
+              out.append(&h, 1);
+              int32_t le = v.val;
+              // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+              out.append(reinterpret_cast<const char*>(&le), sizeof(le));
+          } else if constexpr (std::is_same_v<T, int64_value>) {
+              uint8_t h = make_value_header(basic_type_primitive, prim_int64);
+              out.append(&h, 1);
+              int64_t le = v.val;
+              // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+              out.append(reinterpret_cast<const char*>(&le), sizeof(le));
+          } else if constexpr (std::is_same_v<T, float32_value>) {
+              uint8_t h = make_value_header(basic_type_primitive, prim_float);
+              out.append(&h, 1);
+              float le = v.val;
+              // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+              out.append(reinterpret_cast<const char*>(&le), sizeof(le));
+          } else if constexpr (std::is_same_v<T, float64_value>) {
+              uint8_t h = make_value_header(basic_type_primitive, prim_double);
+              out.append(&h, 1);
+              double le = v.val;
+              // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+              out.append(reinterpret_cast<const char*>(&le), sizeof(le));
+          } else if constexpr (std::is_same_v<T, variant_string_value>) {
+              if (v.val.size() < 64) {
+                  uint8_t h = make_value_header(
+                    basic_type_short_string,
+                    static_cast<uint8_t>(v.val.size()));
+                  out.append(&h, 1);
+                  out.append(v.val.data(), v.val.size());
+              } else {
+                  uint8_t h = make_value_header(
+                    basic_type_primitive, prim_string);
+                  out.append(&h, 1);
+                  auto len = static_cast<uint32_t>(v.val.size());
+                  append_le_uint(out, len, 4);
+                  out.append(v.val.data(), v.val.size());
+              }
+          } else if constexpr (std::is_same_v<T, byte_array_value>) {
+              uint8_t h = make_value_header(basic_type_primitive, prim_binary);
+              out.append(&h, 1);
+              auto len = static_cast<uint32_t>(v.val.size_bytes());
+              append_le_uint(out, len, 4);
+              // Copy iobuf contents
+              for (const auto& frag : v.val) {
+                  out.append(frag.get(), frag.size());
+              }
+          } else if constexpr (
+            std::is_same_v<T, std::unique_ptr<variant_object>>) {
+              encode_object(*v, dictionary, out);
+          } else if constexpr (
+            std::is_same_v<T, std::unique_ptr<variant_array>>) {
+              encode_array(*v, dictionary, out);
+          }
+      },
+      val);
+}
+
+// -- Decoder --
+
+chunked_vector<ss::sstring> decode_dictionary(iobuf_const_parser& p) {
+    uint8_t header = p.consume_type<uint8_t>();
+    uint8_t version = header & 0x0F;
+    vassert(version == 1, "unsupported variant metadata version: {}", version);
+
+    uint8_t offset_size = static_cast<uint8_t>(((header >> 5) & 0x03) + 1);
+
+    uint32_t dict_size = read_le_uint(p, offset_size);
+
+    // Read offset array: dict_size + 1 entries
+    chunked_vector<uint32_t> offsets;
+    offsets.reserve(dict_size + 1);
+    for (uint32_t i = 0; i <= dict_size; ++i) {
+        offsets.push_back(read_le_uint(p, offset_size));
+    }
+
+    // Read string data using offsets
+    chunked_vector<ss::sstring> dictionary;
+    dictionary.reserve(dict_size);
+    for (uint32_t i = 0; i < dict_size; ++i) {
+        uint32_t len = offsets[i + 1] - offsets[i];
+        dictionary.push_back(p.read_string_unsafe(len));
+    }
+
+    return dictionary;
+}
+
+variant_value decode_value(
+  iobuf_const_parser& p, const chunked_vector<ss::sstring>& dictionary);
+
+variant_value decode_object(
+  iobuf_const_parser& p,
+  uint8_t type_info,
+  const chunked_vector<ss::sstring>& dictionary) {
+    uint8_t field_offset_size = static_cast<uint8_t>((type_info & 0x03) + 1);
+    uint8_t field_id_size = static_cast<uint8_t>(((type_info >> 2) & 0x03) + 1);
+
+    uint32_t num_fields = read_le_uint(p, field_offset_size);
+
+    chunked_vector<uint32_t> field_ids;
+    field_ids.reserve(num_fields);
+    for (uint32_t i = 0; i < num_fields; ++i) {
+        field_ids.push_back(read_le_uint(p, field_id_size));
+    }
+
+    chunked_vector<uint32_t> field_offsets;
+    field_offsets.reserve(num_fields);
+    for (uint32_t i = 0; i < num_fields; ++i) {
+        field_offsets.push_back(read_le_uint(p, field_offset_size));
+    }
+
+    auto obj = std::make_unique<variant_object>();
+    obj->fields.reserve(num_fields);
+    for (uint32_t i = 0; i < num_fields; ++i) {
+        vassert(
+          field_ids[i] < dictionary.size(),
+          "field id {} out of range (dictionary size {})",
+          field_ids[i],
+          dictionary.size());
+        const auto& key = dictionary[field_ids[i]];
+        auto field_val = decode_value(p, dictionary);
+        obj->fields.emplace_back(key, std::move(field_val));
+    }
+
+    return obj;
+}
+
+variant_value decode_array(
+  iobuf_const_parser& p,
+  uint8_t type_info,
+  const chunked_vector<ss::sstring>& dictionary) {
+    uint8_t offset_size = static_cast<uint8_t>((type_info & 0x03) + 1);
+
+    uint32_t num_elements = read_le_uint(p, offset_size);
+
+    // Read offsets (we don't strictly need them for sequential decode,
+    // but we consume them to advance the parser).
+    for (uint32_t i = 0; i < num_elements; ++i) {
+        read_le_uint(p, offset_size);
+    }
+
+    auto arr = std::make_unique<variant_array>();
+    arr->elements.reserve(num_elements);
+    for (uint32_t i = 0; i < num_elements; ++i) {
+        arr->elements.push_back(decode_value(p, dictionary));
+    }
+
+    return arr;
+}
+
+variant_value decode_value(
+  iobuf_const_parser& p, const chunked_vector<ss::sstring>& dictionary) {
+    uint8_t header = p.consume_type<uint8_t>();
+    uint8_t basic_type = header & 0x03;
+    uint8_t type_info = (header >> 2) & 0x3F;
+
+    switch (basic_type) {
+    case basic_type_primitive:
+        switch (type_info) {
+        case prim_null:
+            return null_value{};
+        case prim_true:
+            return boolean_value{.val = true};
+        case prim_false:
+            return boolean_value{.val = false};
+        case prim_int32: {
+            auto val = p.consume_type<int32_t>();
+            return int32_value{.val = val};
+        }
+        case prim_int64: {
+            auto val = p.consume_type<int64_t>();
+            return int64_value{.val = val};
+        }
+        case prim_double: {
+            auto val = p.consume_type<double>();
+            return float64_value{.val = val};
+        }
+        case prim_float: {
+            auto val = p.consume_type<float>();
+            return float32_value{.val = val};
+        }
+        case prim_binary: {
+            uint32_t len = read_le_uint(p, 4);
+            iobuf data = p.copy(len);
+            return byte_array_value{.val = std::move(data)};
+        }
+        case prim_string: {
+            uint32_t len = read_le_uint(p, 4);
+            auto str = p.read_string_unsafe(len);
+            return variant_string_value{.val = std::move(str)};
+        }
+        default:
+            vassert(false, "unsupported primitive type_info: {}", type_info);
+        }
+    case basic_type_short_string: {
+        auto str = p.read_string_unsafe(type_info);
+        return variant_string_value{.val = std::move(str)};
+    }
+    case basic_type_object:
+        return decode_object(p, type_info, dictionary);
+    case basic_type_array:
+        return decode_array(p, type_info, dictionary);
+    default:
+        vassert(false, "unsupported basic_type: {}", basic_type);
+    }
+}
+
+} // namespace
+
+encoded_variant encode_variant(const variant_value& val) {
+    // Collect and sort all field names for the dictionary.
+    std::set<ss::sstring> name_set;
+    collect_field_names(val, name_set);
+
+    chunked_vector<ss::sstring> dictionary;
+    dictionary.reserve(name_set.size());
+    for (auto& s : name_set) {
+        dictionary.push_back(s);
+    }
+
+    iobuf metadata = encode_metadata(dictionary);
+
+    iobuf value_buf;
+    encode_value(val, dictionary, value_buf);
+
+    return encoded_variant{
+      .metadata = std::move(metadata),
+      .value = std::move(value_buf),
+    };
+}
+
+variant_value decode_variant(const iobuf& metadata, const iobuf& value) {
+    iobuf_const_parser meta_parser(metadata);
+    auto dictionary = decode_dictionary(meta_parser);
+
+    iobuf_const_parser val_parser(value);
+    return decode_value(val_parser, dictionary);
+}
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/variant_encoding.h
+++ b/src/v/serde/parquet/variant_encoding.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "serde/parquet/variant_value.h"
+
+namespace serde::parquet {
+
+struct encoded_variant {
+    iobuf metadata;
+    iobuf value;
+};
+
+encoded_variant encode_variant(const variant_value& val);
+variant_value decode_variant(const iobuf& metadata, const iobuf& value);
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/variant_json.cc
+++ b/src/v/serde/parquet/variant_json.cc
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "serde/parquet/variant_json.h"
+
+#include "serde/json/parser.h"
+
+#include <seastar/core/coroutine.hh>
+
+#include <fmt/format.h>
+
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+
+namespace serde::parquet {
+
+namespace {
+
+ss::sstring iobuf_to_sstring(iobuf buf) {
+    ss::sstring str;
+    for (const auto& frag : buf) {
+        str.append(frag.get(), frag.size());
+    }
+    return str;
+}
+
+ss::future<variant_value> parse_value(serde::json::parser& p) {
+    switch (p.token()) {
+    case serde::json::token::value_null:
+        co_return null_value{};
+    case serde::json::token::value_true:
+        co_return boolean_value{true};
+    case serde::json::token::value_false:
+        co_return boolean_value{false};
+    case serde::json::token::value_int: {
+        auto v = p.value_int();
+        if (
+          v >= std::numeric_limits<int32_t>::min()
+          && v <= std::numeric_limits<int32_t>::max()) {
+            co_return int32_value{static_cast<int32_t>(v)};
+        }
+        co_return int64_value{v};
+    }
+    case serde::json::token::value_double:
+        co_return float64_value{p.value_double()};
+    case serde::json::token::value_string:
+        co_return variant_string_value{iobuf_to_sstring(p.value_string())};
+    case serde::json::token::start_object: {
+        auto obj = std::make_unique<variant_object>();
+        while (co_await p.next()
+               && p.token() != serde::json::token::end_object) {
+            auto key = iobuf_to_sstring(p.value_string());
+            co_await p.next();
+            auto val = co_await parse_value(p);
+            obj->fields.emplace_back(std::move(key), std::move(val));
+        }
+        sort_variant_object(*obj);
+        co_return std::move(obj);
+    }
+    case serde::json::token::start_array: {
+        auto arr = std::make_unique<variant_array>();
+        while (co_await p.next()
+               && p.token() != serde::json::token::end_array) {
+            arr->elements.push_back(co_await parse_value(p));
+        }
+        co_return std::move(arr);
+    }
+    default:
+        throw std::runtime_error(
+          fmt::format("unexpected JSON token: {}", p.token()));
+    }
+}
+
+} // namespace
+
+ss::future<variant_value> parse_json_to_variant(iobuf json_data) {
+    serde::json::parser p(std::move(json_data));
+    co_await p.next();
+    co_return co_await parse_value(p);
+}
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/variant_json.h
+++ b/src/v/serde/parquet/variant_json.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "serde/parquet/variant_value.h"
+
+#include <seastar/core/future.hh>
+
+namespace serde::parquet {
+
+/// \brief Parse a JSON iobuf into a variant_value.
+///
+/// Uses serde::json::parser (async streaming). Type inference:
+/// integers -> int32/int64, decimals -> float64, strings ->
+/// variant_string_value.
+ss::future<variant_value> parse_json_to_variant(iobuf json_data);
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/variant_schema.cc
+++ b/src/v/serde/parquet/variant_schema.cc
@@ -1,0 +1,347 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "serde/parquet/variant_schema.h"
+
+#include "serde/parquet/variant_encoding.h"
+
+#include <algorithm>
+
+namespace serde::parquet {
+
+namespace {
+
+logical_type logical_type_for_shredded_field(const physical_type& pt) {
+    if (std::holds_alternative<byte_array_type>(pt)) {
+        return string_type{};
+    }
+    return {};
+}
+
+/// Insert a shredding field into a typed_value group schema, creating
+/// intermediate group nodes for nested paths as needed.
+void insert_shredded_field(
+  schema_element& parent,
+  const chunked_vector<ss::sstring>& path,
+  size_t depth,
+  const physical_type& pt) {
+    if (depth + 1 == path.size()) {
+        parent.children.push_back(
+          schema_element{
+            .type = pt,
+            .repetition_type = field_repetition_type::optional,
+            .path = {ss::sstring(path[depth])},
+            .logical_type = logical_type_for_shredded_field(pt),
+          });
+        return;
+    }
+    const auto& segment = path[depth];
+    auto it = std::ranges::find_if(
+      parent.children,
+      [&segment](const schema_element& e) { return e.name() == segment; });
+    if (it == parent.children.end()) {
+        parent.children.push_back(
+          schema_element{
+            .type = std::monostate{},
+            .repetition_type = field_repetition_type::optional,
+            .path = {ss::sstring(segment)},
+          });
+        it = parent.children.end() - 1;
+    }
+    insert_shredded_field(*it, path, depth + 1, pt);
+}
+
+/// Build the typed_value group members matching the schema, recursively.
+/// Each shredding field's value maps to a leaf; intermediate groups become
+/// group_value nodes. The `typed_values` vector is consumed in order,
+/// with `idx` tracking which field we are on.
+void build_typed_value_members(
+  group_value& out,
+  const schema_element& schema_node,
+  chunked_vector<value>& typed_values,
+  size_t& idx) {
+    for (const auto& child : schema_node.children) {
+        if (child.is_leaf()) {
+            out.push_back(group_member{std::move(typed_values[idx++])});
+        } else {
+            group_value nested;
+            build_typed_value_members(nested, child, typed_values, idx);
+            out.push_back(group_member{value{std::move(nested)}});
+        }
+    }
+}
+
+bool is_residual_trivial(const variant_value& residual) {
+    if (auto* obj = std::get_if<std::unique_ptr<variant_object>>(&residual)) {
+        return *obj && (*obj)->fields.empty();
+    }
+    return false;
+}
+
+} // namespace
+
+schema_element build_variant_schema(
+  ss::sstring name,
+  field_repetition_type rep,
+  const variant_shredding_schema& shredding) {
+    bool has_shredding = !shredding.fields.empty();
+
+    schema_element root{
+      .type = std::monostate{},
+      .repetition_type = rep,
+      .path = {std::move(name)},
+      .logical_type = variant_type{},
+    };
+
+    root.children.push_back(
+      schema_element{
+        .type = byte_array_type{},
+        .repetition_type = field_repetition_type::required,
+        .path = {ss::sstring("metadata")},
+      });
+
+    root.children.push_back(
+      schema_element{
+        .type = byte_array_type{},
+        .repetition_type = has_shredding ? field_repetition_type::optional
+                                         : field_repetition_type::required,
+        .path = {ss::sstring("value")},
+      });
+
+    if (has_shredding) {
+        schema_element typed_value{
+          .type = std::monostate{},
+          .repetition_type = field_repetition_type::optional,
+          .path = {ss::sstring("typed_value")},
+        };
+        for (const auto& field : shredding.fields) {
+            insert_shredded_field(typed_value, field.field_path, 0, field.type);
+        }
+        root.children.push_back(std::move(typed_value));
+    }
+
+    return root;
+}
+
+group_value encode_variant_for_writer(
+  variant_value val, const variant_shredding_schema& shredding) {
+    if (shredding.fields.empty()) {
+        auto enc = encode_variant(val);
+        group_value gv;
+        gv.push_back(
+          group_member{value{byte_array_value{std::move(enc.metadata)}}});
+        gv.push_back(
+          group_member{value{byte_array_value{std::move(enc.value)}}});
+        return gv;
+    }
+
+    auto shredded = shred_variant(std::move(val), shredding);
+    auto enc = encode_variant(shredded.residual);
+
+    group_value gv;
+    gv.push_back(
+      group_member{value{byte_array_value{std::move(enc.metadata)}}});
+
+    if (is_residual_trivial(shredded.residual)) {
+        gv.push_back(group_member{value{null_value{}}});
+    } else {
+        gv.push_back(
+          group_member{value{byte_array_value{std::move(enc.value)}}});
+    }
+
+    // Build typed_value group matching the schema structure.
+    auto typed_value_schema = build_variant_schema("tmp", {}, shredding);
+    // typed_value is the third child (index 2).
+    const auto& tv_schema = typed_value_schema.children[2];
+
+    group_value tv;
+    size_t idx = 0;
+    build_typed_value_members(tv, tv_schema, shredded.typed_values, idx);
+    gv.push_back(group_member{value{std::move(tv)}});
+
+    return gv;
+}
+
+namespace {
+
+/// Convert a parquet value read from a typed_value leaf back to a
+/// variant_value, reversing the conversion done by try_extract in the
+/// shredder.
+variant_value
+parquet_value_to_variant(const value& v, const physical_type& pt) {
+    if (std::holds_alternative<null_value>(v)) {
+        return null_value{};
+    }
+    if (std::holds_alternative<boolean_value>(v)) {
+        return std::get<boolean_value>(v);
+    }
+    if (std::holds_alternative<int32_value>(v)) {
+        return std::get<int32_value>(v);
+    }
+    if (std::holds_alternative<int64_value>(v)) {
+        return std::get<int64_value>(v);
+    }
+    if (std::holds_alternative<float32_value>(v)) {
+        return std::get<float32_value>(v);
+    }
+    if (std::holds_alternative<float64_value>(v)) {
+        return std::get<float64_value>(v);
+    }
+    if (auto* ba = std::get_if<byte_array_value>(&v)) {
+        if (std::holds_alternative<byte_array_type>(pt)) {
+            // The shredder encodes variant_string_value as byte_array_value,
+            // so reverse that here.
+            return variant_string_value{ba->val.linearize_to_string()};
+        }
+        return byte_array_value{ba->val.copy()};
+    }
+    return null_value{};
+}
+
+/// Insert a variant_value at the given field_path within a variant_object,
+/// creating intermediate objects as needed.
+void insert_at_path(
+  variant_object& root,
+  const chunked_vector<ss::sstring>& path,
+  variant_value leaf_val) {
+    variant_object* current = &root;
+    for (size_t i = 0; i + 1 < path.size(); ++i) {
+        const auto& key = path[i];
+        auto it = std::ranges::find_if(
+          current->fields, [&key](const auto& p) { return p.first == key; });
+        if (it == current->fields.end()) {
+            auto nested = std::make_unique<variant_object>();
+            current->fields.emplace_back(
+              ss::sstring(key), variant_value{std::move(nested)});
+            auto* obj_ptr = std::get_if<std::unique_ptr<variant_object>>(
+              &current->fields.back().second);
+            current = obj_ptr->get();
+        } else {
+            auto* obj_ptr = std::get_if<std::unique_ptr<variant_object>>(
+              &it->second);
+            if (!obj_ptr || !*obj_ptr) {
+                it->second = variant_value{std::make_unique<variant_object>()};
+                obj_ptr = std::get_if<std::unique_ptr<variant_object>>(
+                  &it->second);
+            }
+            current = obj_ptr->get();
+        }
+    }
+    current->fields.emplace_back(ss::sstring(path.back()), std::move(leaf_val));
+}
+
+/// Recursively sort all variant_objects in the tree.
+void sort_variant_object_recursive(variant_value& val) {
+    auto* obj_ptr = std::get_if<std::unique_ptr<variant_object>>(&val);
+    if (!obj_ptr || !*obj_ptr) {
+        return;
+    }
+    for (auto& [_, child] : (*obj_ptr)->fields) {
+        sort_variant_object_recursive(child);
+    }
+    sort_variant_object(*obj_ptr->get());
+}
+
+size_t count_leaf_descendants(const schema_element& e) {
+    if (e.is_leaf()) {
+        return 1;
+    }
+    size_t count = 0;
+    for (const auto& c : e.children) {
+        count += count_leaf_descendants(c);
+    }
+    return count;
+}
+
+/// Extract typed leaf values from the typed_value group, navigating nested
+/// groups to match the schema structure built by build_variant_schema.
+void extract_typed_values_from_group(
+  const group_value& group,
+  const schema_element& schema_node,
+  const chunked_vector<variant_shredding_field>& fields,
+  size_t& field_idx,
+  variant_object& target) {
+    size_t child_idx = 0;
+    for (const auto& schema_child : schema_node.children) {
+        if (child_idx >= group.size()) {
+            break;
+        }
+        const auto& member = group[child_idx];
+        if (schema_child.is_leaf()) {
+            if (field_idx < fields.size()) {
+                const auto& field = fields[field_idx];
+                if (!std::holds_alternative<null_value>(member.field)) {
+                    auto vval = parquet_value_to_variant(
+                      member.field, field.type);
+                    if (!std::holds_alternative<null_value>(vval)) {
+                        insert_at_path(
+                          target, field.field_path, std::move(vval));
+                    }
+                }
+                ++field_idx;
+            }
+        } else {
+            const auto* nested = std::get_if<group_value>(&member.field);
+            if (nested) {
+                extract_typed_values_from_group(
+                  *nested, schema_child, fields, field_idx, target);
+            } else {
+                field_idx += count_leaf_descendants(schema_child);
+            }
+        }
+        ++child_idx;
+    }
+}
+
+} // unnamed namespace
+
+variant_value decode_variant_from_reader(
+  const group_value& variant_group, const variant_shredding_schema& shredding) {
+    if (shredding.fields.empty()) {
+        // Unshredded: group has metadata + value.
+        const auto& meta_ba = std::get<byte_array_value>(
+          variant_group[0].field);
+        const auto& val_ba = std::get<byte_array_value>(variant_group[1].field);
+        return decode_variant(meta_ba.val, val_ba.val);
+    }
+
+    // Shredded: group has metadata + value (possibly null) + typed_value.
+    const auto& meta_ba = std::get<byte_array_value>(variant_group[0].field);
+
+    variant_value result;
+    if (auto* val_ba = std::get_if<byte_array_value>(&variant_group[1].field)) {
+        result = decode_variant(meta_ba.val, val_ba->val);
+    } else {
+        result = variant_value{std::make_unique<variant_object>()};
+    }
+
+    const auto* typed_group = std::get_if<group_value>(&variant_group[2].field);
+    if (typed_group) {
+        auto tv_schema = build_variant_schema("tmp", {}, shredding);
+        const auto& tv_schema_node = tv_schema.children[2];
+
+        auto* obj_ptr = std::get_if<std::unique_ptr<variant_object>>(&result);
+        if (obj_ptr && *obj_ptr) {
+            size_t field_idx = 0;
+            extract_typed_values_from_group(
+              *typed_group,
+              tv_schema_node,
+              shredding.fields,
+              field_idx,
+              **obj_ptr);
+        }
+    }
+
+    sort_variant_object_recursive(result);
+    return result;
+}
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/variant_schema.h
+++ b/src/v/serde/parquet/variant_schema.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "serde/parquet/schema.h"
+#include "serde/parquet/value.h"
+#include "serde/parquet/variant_shredder.h"
+#include "serde/parquet/variant_value.h"
+
+namespace serde::parquet {
+
+/// \brief Build a Parquet schema_element for a VARIANT column.
+///
+/// Without shredding: group with metadata (required BYTE_ARRAY) +
+/// value (required BYTE_ARRAY).
+///
+/// With shredding: group with metadata (required BYTE_ARRAY) +
+/// value (optional BYTE_ARRAY) + typed_value (optional group with
+/// typed sub-columns for each shredding field).
+schema_element build_variant_schema(
+  ss::sstring name,
+  field_repetition_type rep,
+  const variant_shredding_schema& shredding = {});
+
+/// \brief Convert a variant_value into a group_value for the writer.
+///
+/// Handles shredding, binary encoding of the residual, and
+/// construction of the group_value matching the schema produced by
+/// build_variant_schema with the same shredding schema.
+group_value encode_variant_for_writer(
+  variant_value val, const variant_shredding_schema& shredding = {});
+
+/// \brief Decode a variant_value from a group_value produced by the reader.
+///
+/// For unshredded variants: extracts metadata + value byte arrays and
+/// calls decode_variant.
+/// For shredded variants: also merges typed values back into the
+/// decoded residual (unshredding).
+variant_value decode_variant_from_reader(
+  const group_value& variant_group,
+  const variant_shredding_schema& shredding = {});
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/variant_shredder.cc
+++ b/src/v/serde/parquet/variant_shredder.cc
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "serde/parquet/variant_shredder.h"
+
+#include "bytes/iobuf.h"
+
+#include <algorithm>
+
+namespace serde::parquet {
+
+namespace {
+
+/// Navigate a field_path through the variant_value tree, returning a pointer
+/// to the leaf variant_value if the path is valid, or nullptr if any step
+/// fails (not an object or key not found).
+variant_value*
+navigate_path(variant_value& root, const chunked_vector<ss::sstring>& path) {
+    variant_value* current = &root;
+    for (const auto& key : path) {
+        auto* obj_ptr = std::get_if<std::unique_ptr<variant_object>>(current);
+        if (!obj_ptr || !*obj_ptr) {
+            return nullptr;
+        }
+        auto& fields = (*obj_ptr)->fields;
+        auto it = std::ranges::find_if(
+          fields, [&key](const auto& p) { return p.first == key; });
+        if (it == fields.end()) {
+            return nullptr;
+        }
+        current = &it->second;
+    }
+    return current;
+}
+
+/// Check whether a variant_value's runtime type matches the requested
+/// physical_type, and if so convert it to a parquet value.
+std::optional<value>
+try_extract(const variant_value& vval, const physical_type& pt) {
+    return std::visit(
+      [&vval](const auto& type_tag) -> std::optional<value> {
+          using T = std::decay_t<decltype(type_tag)>;
+          if constexpr (std::is_same_v<T, std::monostate>) {
+              return std::nullopt;
+          } else if constexpr (std::is_same_v<T, bool_type>) {
+              if (auto* v = std::get_if<boolean_value>(&vval)) {
+                  return value{*v};
+              }
+              return std::nullopt;
+          } else if constexpr (std::is_same_v<T, i32_type>) {
+              if (auto* v = std::get_if<int32_value>(&vval)) {
+                  return value{*v};
+              }
+              return std::nullopt;
+          } else if constexpr (std::is_same_v<T, i64_type>) {
+              if (auto* v = std::get_if<int64_value>(&vval)) {
+                  return value{*v};
+              }
+              return std::nullopt;
+          } else if constexpr (std::is_same_v<T, f32_type>) {
+              if (auto* v = std::get_if<float32_value>(&vval)) {
+                  return value{*v};
+              }
+              return std::nullopt;
+          } else if constexpr (std::is_same_v<T, f64_type>) {
+              if (auto* v = std::get_if<float64_value>(&vval)) {
+                  return value{*v};
+              }
+              return std::nullopt;
+          } else if constexpr (std::is_same_v<T, byte_array_type>) {
+              if (auto* v = std::get_if<variant_string_value>(&vval)) {
+                  return value{byte_array_value{iobuf::from(v->val)}};
+              }
+              if (auto* v = std::get_if<byte_array_value>(&vval)) {
+                  return value{byte_array_value{v->val.copy()}};
+              }
+              return std::nullopt;
+          } else {
+              return std::nullopt;
+          }
+      },
+      pt);
+}
+
+/// Remove a field at the given path from the variant_value tree. Navigates
+/// to the parent object and erases the final key.
+void remove_field(
+  variant_value& root, const chunked_vector<ss::sstring>& path) {
+    if (path.empty()) {
+        return;
+    }
+    variant_value* current = &root;
+    for (size_t i = 0; i < path.size() - 1; ++i) {
+        auto* obj_ptr = std::get_if<std::unique_ptr<variant_object>>(current);
+        if (!obj_ptr || !*obj_ptr) {
+            return;
+        }
+        auto& fields = (*obj_ptr)->fields;
+        auto it = std::ranges::find_if(
+          fields, [&key = path[i]](const auto& p) { return p.first == key; });
+        if (it == fields.end()) {
+            return;
+        }
+        current = &it->second;
+    }
+    auto* obj_ptr = std::get_if<std::unique_ptr<variant_object>>(current);
+    if (!obj_ptr || !*obj_ptr) {
+        return;
+    }
+    auto& fields = (*obj_ptr)->fields;
+    const auto& last_key = path.back();
+    // chunked_vector lacks iterator erase, so find the index and swap-remove.
+    for (size_t i = 0; i < fields.size(); ++i) {
+        if (fields[i].first == last_key) {
+            if (i + 1 < fields.size()) {
+                std::swap(fields[i], fields[fields.size() - 1]);
+            }
+            fields.pop_back();
+            break;
+        }
+    }
+}
+
+} // namespace
+
+shredded_variant
+shred_variant(variant_value val, const variant_shredding_schema& schema) {
+    shredded_variant result;
+    result.typed_values.reserve(schema.fields.size());
+
+    for (const auto& field : schema.fields) {
+        auto* leaf = navigate_path(val, field.field_path);
+        if (!leaf) {
+            result.typed_values.emplace_back(null_value{});
+            continue;
+        }
+        auto extracted = try_extract(*leaf, field.type);
+        if (!extracted) {
+            result.typed_values.emplace_back(null_value{});
+            continue;
+        }
+        result.typed_values.emplace_back(std::move(*extracted));
+        remove_field(val, field.field_path);
+    }
+
+    result.residual = std::move(val);
+    return result;
+}
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/variant_shredder.h
+++ b/src/v/serde/parquet/variant_shredder.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "container/chunked_vector.h"
+#include "serde/parquet/schema.h"
+#include "serde/parquet/value.h"
+#include "serde/parquet/variant_value.h"
+
+#include <seastar/core/sstring.hh>
+
+namespace serde::parquet {
+
+struct variant_shredding_field {
+    chunked_vector<ss::sstring> field_path;
+    physical_type type;
+};
+
+struct variant_shredding_schema {
+    chunked_vector<variant_shredding_field> fields;
+};
+
+struct shredded_variant {
+    /// One parquet value per field in the shredding schema, in order.
+    /// null_value if the field is absent or has wrong type.
+    chunked_vector<value> typed_values;
+
+    /// The variant value with shredded fields removed.
+    variant_value residual;
+};
+
+shredded_variant
+shred_variant(variant_value val, const variant_shredding_schema& schema);
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/variant_value.cc
+++ b/src/v/serde/parquet/variant_value.cc
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "serde/parquet/variant_value.h"
+
+#include <algorithm>
+
+namespace serde::parquet {
+
+bool operator==(const variant_value& lhs, const variant_value& rhs) {
+    if (lhs.index() != rhs.index()) {
+        return false;
+    }
+    return std::visit(
+      [&rhs](const auto& lhs_val) -> bool {
+          using T = std::decay_t<decltype(lhs_val)>;
+          const auto& rhs_val = std::get<T>(rhs);
+          if constexpr (std::is_same_v<T, std::unique_ptr<variant_object>>) {
+              if (!lhs_val && !rhs_val) {
+                  return true;
+              }
+              if (!lhs_val || !rhs_val) {
+                  return false;
+              }
+              return *lhs_val == *rhs_val;
+          } else if constexpr (
+            std::is_same_v<T, std::unique_ptr<variant_array>>) {
+              if (!lhs_val && !rhs_val) {
+                  return true;
+              }
+              if (!lhs_val || !rhs_val) {
+                  return false;
+              }
+              return *lhs_val == *rhs_val;
+          } else {
+              return lhs_val == rhs_val;
+          }
+      },
+      lhs);
+}
+
+bool variant_object::operator==(const variant_object& other) const {
+    if (fields.size() != other.fields.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < fields.size(); ++i) {
+        if (fields[i].first != other.fields[i].first) {
+            return false;
+        }
+        if (!(fields[i].second == other.fields[i].second)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool variant_array::operator==(const variant_array& other) const {
+    if (elements.size() != other.elements.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < elements.size(); ++i) {
+        if (!(elements[i] == other.elements[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+variant_value copy_variant(const variant_value& val) {
+    return std::visit(
+      [](const auto& v) -> variant_value {
+          using T = std::decay_t<decltype(v)>;
+          if constexpr (std::is_same_v<T, std::unique_ptr<variant_object>>) {
+              auto obj = std::make_unique<variant_object>();
+              for (const auto& [key, field_val] : v->fields) {
+                  obj->fields.emplace_back(
+                    ss::sstring(key), copy_variant(field_val));
+              }
+              return obj;
+          } else if constexpr (
+            std::is_same_v<T, std::unique_ptr<variant_array>>) {
+              auto arr = std::make_unique<variant_array>();
+              for (const auto& elem : v->elements) {
+                  arr->elements.emplace_back(copy_variant(elem));
+              }
+              return arr;
+          } else if constexpr (std::is_same_v<T, byte_array_value>) {
+              return byte_array_value{.val = v.val.copy()};
+          } else {
+              return v;
+          }
+      },
+      val);
+}
+
+void sort_variant_object(variant_object& obj) {
+    std::ranges::sort(obj.fields, [](const auto& a, const auto& b) {
+        return a.first < b.first;
+    });
+}
+
+} // namespace serde::parquet

--- a/src/v/serde/parquet/variant_value.h
+++ b/src/v/serde/parquet/variant_value.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "container/chunked_vector.h"
+#include "serde/parquet/value.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <memory>
+#include <utility>
+#include <variant>
+
+namespace serde::parquet {
+
+struct variant_object;
+struct variant_array;
+
+struct variant_string_value {
+    ss::sstring val;
+    bool operator==(const variant_string_value&) const = default;
+};
+
+/// In-memory representation of a Parquet VARIANT value.
+///
+/// A recursive typed value tree with objects, arrays, and primitives.
+/// Used as the common intermediate between input adapters (JSON, etc.)
+/// and the variant binary encoder/shredder.
+using variant_value = std::variant<
+  null_value,
+  boolean_value,
+  int32_value,
+  int64_value,
+  float32_value,
+  float64_value,
+  byte_array_value,
+  variant_string_value,
+  std::unique_ptr<variant_object>,
+  std::unique_ptr<variant_array>>;
+
+bool operator==(const variant_value& lhs, const variant_value& rhs);
+
+/// A variant object with string-keyed fields, sorted by key for
+/// deterministic encoding.
+struct variant_object {
+    chunked_vector<std::pair<ss::sstring, variant_value>> fields;
+    bool operator==(const variant_object&) const;
+};
+
+/// A variant array of heterogeneous values.
+struct variant_array {
+    chunked_vector<variant_value> elements;
+    bool operator==(const variant_array&) const;
+};
+
+/// Deep copy a variant_value (unique_ptr members are not copyable).
+variant_value copy_variant(const variant_value& val);
+
+/// Sort a variant_object's fields by key lexicographically.
+void sort_variant_object(variant_object& obj);
+
+} // namespace serde::parquet


### PR DESCRIPTION
Adds full VARIANT support spanning the parquet and iceberg layers:
variant_value type for the Parquet VARIANT logical type, binary
encoder/decoder per the variant encoding spec, JSON input adapter
for constructing variants from JSON text, shredder for decomposing
nested variants into flat parquet columns, and schema/writer/reader
convenience APIs. On the iceberg side, adds variant_type to the
datatype system with parquet schema mapping.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>